### PR TITLE
Made delete-file advice compatible with emacs 24.

### DIFF
--- a/eclim-java.el
+++ b/eclim-java.el
@@ -89,7 +89,7 @@ sources."
     (when (buffer-modified-p) (save-buffer)) ;; auto-save current buffer, prompt on saving others
     (when save-others (save-some-buffers nil (lambda () (string-match "\\.java$" (buffer-file-name)))))))
 
-(defadvice delete-file (around eclim--delete-file (filename) activate)
+(defadvice delete-file (around eclim--delete-file activate)
   "Advice the `delete-file' function to trigger a source update
 in eclim when appropriate."
   (let ((buf (current-buffer))
@@ -109,7 +109,7 @@ in eclim when appropriate."
 declaration has been found. TYPE may be either 'class',
 'interface', 'enum' or nil, meaning 'match all of the above'."
   (save-excursion
-    (if (re-search-backward 
+    (if (re-search-backward
 	 (concat (or type "\\(class\\|interface\\|enum\\)") "\\s-+\\([^<{\s-]+\\)") nil t)
 	(match-string 2)
       "")))
@@ -173,7 +173,7 @@ has been found."
   (interactive)
   (let* ((i (eclim--java-identifier-at-point t))
 	 (n (read-string (concat "Rename " (cdr i) " to: ") (cdr i))))
-    (eclim/with-results files ("java_refactor_rename" "-p" "-e" "-f" ("-n" n) 
+    (eclim/with-results files ("java_refactor_rename" "-p" "-e" "-f" ("-n" n)
 			       ("-o" (car i)) ("-l" (length (cdr i))))
 			(when (not (string= "files:" (first files)))
 			  (error (first files)))
@@ -283,7 +283,7 @@ start."
       (if (and full (re-search-forward boundary nil t))
 	  (backward-char))
       (let ((end (point))
-	    (start (progn 
+	    (start (progn
 		     (if (re-search-backward boundary nil t) (forward-char))
 		     (point))))
 	(cons (eclim--byte-offset)
@@ -422,14 +422,14 @@ implemnt/override, then inserts a skeleton for the chosen
 method."
   (interactive)
   (eclim/with-results response ("java_impl" "-p" "-f" "-o")
-		      (let* ((methods  
+		      (let* ((methods
 			      (remove-if (lambda (element) (string-match "//" element))
 					 (remove-if-not (lambda (element) (string-match "(.*)" element))
 							response)))
 			     (start (point)))
-			(insert 
+			(insert
 			 "@Override\n"
-			 (replace-regexp-in-string " abstract " " " 
+			 (replace-regexp-in-string " abstract " " "
 						   (eclim--completing-read "Signature: " methods)) " {}")
 			(backward-char)
 			(indent-region start (point)))))


### PR DESCRIPTION
- eclim-java.el: Delete delete-file advice arglist to make it compatible with emacs 24.

This is a rework from my previous pull request to reflect the latest changes in the main repo.
