### PR TITLE
Removed comment stating that vendor dir is optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ from eclipse to emacs.
 1. add the following code to your emacs startup script
 
         (add-to-list 'load-path (expand-file-name "/path/to/emacs-eclim/"))
-        ;; only add the vendor path when you want to use the libraries provided with emacs-eclim
         (add-to-list 'load-path (expand-file-name "~/coding/git/emacs-eclim/vendor"))
         (require 'eclim)
 


### PR DESCRIPTION
The comment in the README file example configuration states that vendor path is optional and only required to make use of additional functionality, but eclim won't load if it's not included.
- README.md: vendor dir must be in the load-path to load eclim
