### PR TITLE
Adding the vendor directory is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ from eclipse to emacs.
 1. add the following code to your emacs startup script
 
         (add-to-list 'load-path (expand-file-name "/path/to/emacs-eclim/"))
-        ;; only add the vendor path when you want to use the libraries provided with emacs-eclim
-        (add-to-list 'load-path (expand-file-name "~/coding/git/emacs-eclim/vendor"))
+        (add-to-list 'load-path (expand-file-name "/path/to/emacs-eclim/vendor"))
         (require 'eclim)
 
         (setq eclim-auto-save t)


### PR DESCRIPTION
Adding the vendor directory is required as it includes 'decompile, a dependency of 'eclim-java
