### PR TITLE
Adds an eclim-running-p function to detect if eclim is running

### DIFF
--- a/eclim.el
+++ b/eclim.el
@@ -184,7 +184,7 @@ an error if the connection is refused. Automatically calls
 			(revert-buffer t t t)))
 	 ,res))))
 
-(defun eclim-running-p ()
+(defun eclim--running-p ()
   "Returns t if eclim is currently capable of receiving commands,
 nil otherwise."
   (condition-case nil


### PR DESCRIPTION
Adds an eclim-running-p function to detect whether eclim is currently capable of receiving commands
