### PR TITLE
Classpath command. Return project classpath for current buffer.

### DIFF
--- a/eclim-project.el
+++ b/eclim-project.el
@@ -257,6 +257,14 @@
   (eclim--check-project project)
   (eclim--call-process "project_rename" "-p" project "-n" new-name))
 
+(defun eclim/project-classpath (&optional delimiter)
+  "return project classpath for the current buffer."
+  (eclim--check-project eclim--project-name)
+  (car (apply 'eclim--call-process
+              (eclim--build-command "java_classpath"
+                                    "-p" eclim--project-name
+                                    "-d" delimiter))))
+
 (defun eclim-project-rename (project name)
   (interactive (let ((project-name (eclim--project-read t)))
                  (list project-name (read-string (concat "Rename <" project-name "> To: ")))))


### PR DESCRIPTION
Classpath command. Return project classpath for current buffer. Can be used by flymake to get in buffer warnings and errors: https://gist.github.com/1225030

Not sure I followed conventions in emacs-eclim for example using buffer-local var `eclim--project-name`...
