### PR TITLE
make eclim--find-file aware of current file

### DIFF
--- a/eclim.el
+++ b/eclim.el
@@ -233,7 +233,8 @@ FILENAME is given, return that file's  project name instead."
 
 (defun eclim--find-file (path-to-file)
   (if (not (string-match-p "!" path-to-file))
-      (find-file-other-window path-to-file)
+      (unless (string= path-to-file (buffer-file-name))
+	(find-file-other-window path-to-file))
     (let* ((parts (split-string path-to-file "!"))
            (archive-name (replace-regexp-in-string eclim--compressed-urls-regexp "" (first parts)))
            (file-name (second parts)))


### PR DESCRIPTION
Make eclim--find-file aware of current  file so it doesn't open it again. This makes eclim-java-find-declarartion behave more similar to find-tag, i.e., jumping in the same file if value is defined there, open a new file otherwise. There is another commit that removes empty spaces... I'm not sure if this is the right way of doing it or I should create a different pull request for this things.
