### PR TITLE
Fixed the regexp used to strip out compressed URL part of file name

### DIFF
--- a/eclim.el
+++ b/eclim.el
@@ -112,7 +112,7 @@ saved."
     ("utf-8-unix" . "utf-8")
     ("utf-8-emacs-unix" . "utf-8")))
 
-(defvar eclim--compressed-urls-regexp "\\(^jar:file://\\)\\|\\(^zip://\\)")
+(defvar eclim--compressed-urls-regexp "^\\(\\(?:jar\\|file\\|zip\\)://\\)")
 (defvar eclim--compressed-file-path-replacement-regexp "\\\\")
 (defvar eclim--compressed-file-path-removal-regexp "^/")
 


### PR DESCRIPTION
I don't know what went wrong (can't see it in history), but the URL fixing regexp was not quite right. It created 'file:' directories in my working area, and it failed to find compressed references.

This regexp seems to make things right again.
