### PR TITLE
Made eclim--project-name compare via file-truename

### DIFF
--- a/eclim.el
+++ b/eclim.el
@@ -336,10 +336,10 @@ FILENAME is given, return that file's  project name instead."
                                (or
                                 (find project-dir project-list ;; case sensitive
                                       :key (lambda (e) (assoc-default 'path e))
-                                      :test #'string=)
+                                      :test (lambda (s1 s2) (string= (file-truename s1) (file-truename s2))))
                                 (find project-dir project-list ;; case insensitive
                                       :key (lambda (e) (assoc-default 'path e))
-                                      :test (lambda (s1 s2) (string= (downcase s1) (downcase s2)))))))))))
+                                      :test (lambda (s1 s2) (string= (downcase (file-truename s1)) (downcase (file-truename s2))))))))))))
 
 (defun eclim--find-file (path-to-file)
   (if (not (string-match-p "!" path-to-file))


### PR DESCRIPTION
In issue #59 I noticed a side-effect when the project dir is in some symlinked path. If either Eclipse or Emacs uses the symlinks, and the other doesn't, emacs-eclim will fail to identify the project, so that eclim will not get a project name. This little commit fixes that by using the Emacs `file-truename` function to resolve the paths and compare them instead.
