### PR TITLE
 Fixed eclim-package-and-class when the package is empty

### DIFF
--- a/eclim-java.el
+++ b/eclim-java.el
@@ -476,7 +476,10 @@ method."
                    (assoc-default 'completions (eclim/java-complete))))))
 
 (defun eclim-package-and-class ()
-  (concat (eclim--java-current-package) "." (eclim--java-current-class-name)))
+  (let ((package-name (eclim--java-current-package))
+        (class-name   (eclim--java-current-class-name)))
+    (if package-name (concat package-name "." class-name)
+      class-name)))
 
 (defun eclim-run-class ()
   "Run the current class."


### PR DESCRIPTION
Hey,

One should be able to run a class with no "package" directive, but
eclim-package-and-class returned ".ClassName" instead of just "ClassName",
causing an error when running such a class.

This just adds a special case to fix it.
