### PR TITLE
Quick lookup of documentation of Java elements

### DIFF
--- a/eclim-java.el
+++ b/eclim-java.el
@@ -579,7 +579,7 @@ method."
             (pop-to-buffer "*java doc*")
             (use-local-map eclim-java-show-documentation-map)
 
-            (eclim-java-show-documentation-and-format doc)
+            (eclim--java-show-documentation-and-format doc)
 
             (message (substitute-command-keys
                       (concat
@@ -590,7 +590,7 @@ method."
       (message "No element found at point."))))
 
 
-(defun eclim-java-show-documentation-and-format (doc &optional add-to-history)
+(defun eclim--java-show-documentation-and-format (doc &optional add-to-history)
   (make-local-variable 'eclim-java-show-documentation-history)
   (setq eclim-java-show-documentation-history
         (if add-to-history
@@ -618,7 +618,7 @@ method."
   (when add-to-history
     (goto-char (point-max))
     (insert "\n\n")
-    (insert-text-button "back" 'action 'eclim-java-show-documentation-go-back))
+    (insert-text-button "back" 'action 'eclim--java-show-documentation-go-back))
 
   (goto-char (point-min)))
 
@@ -629,7 +629,7 @@ method."
     (if (string-match "^eclipse-javadoc" url)
         (eclim/with-results doc ("java_element_doc"
                                  ("-u" url))
-          (eclim-java-show-documentation-and-format doc t))
+          (eclim--java-show-documentation-and-format doc t))
 
       (if (string-match "^\.\." url)
           (let* ((doc-root-vars '(eclim-java-documentation-root
@@ -659,7 +659,7 @@ method."
                  url)))))
 
 
-(defun eclim-java-show-documentation-go-back (link)
+(defun eclim--java-show-documentation-go-back (link)
   (erase-buffer)
   (insert (pop eclim-java-show-documentation-history))
   (goto-char (point-min)))


### PR DESCRIPTION
I implemented this one too, because it is the other basic feature (besides completion) which is very useful in everyday coding.

It requires a fairly recent eclim which has the command java_element_doc (1.7.x also supports it, I use that).

I did not assign a key for it, because it needs an easy key combo and the current C-c .. eclim keys are a too complex for that in my opinion. I use F1, but I did not add it to the official code, because it's not very emacsy, so I leave the key assignment to you. (Eclipse uses F2 for this.)

You can test it with F1 in a Java buffer with this:

(local-set-key (kbd "<f1>") 'eclim-java-show-documentation-for-current-element)

Just put the cursor on a function, class or other element and press F1.
