### PR TITLE
move contribution guidelines into CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+The project is under active development and we are always looking for
+assistance. See the
+[Roadmap](http://wiki.github.com/senny/emacs-eclim/roadmap) wiki page
+for more information.
+
+1. Fork emacs-eclim
+2. Create a topic branch - `git checkout -b my_branch`
+3. Make your changes and update the History.txt file
+4. Push to your branch - `git push origin my_branch`
+5. Send me a pull-request for your topic branch
+6. That's it!

--- a/README.md
+++ b/README.md
@@ -168,17 +168,8 @@ program.
 
 ## Contributing
 
-The project is under active development and we are always looking for
-assistance. See the
-[Roadmap](http://wiki.github.com/senny/emacs-eclim/roadmap) wiki page
-for more information.
-
-1. Fork emacs-eclim
-2. Create a topic branch - `git checkout -b my_branch`
-3. Make your changes and update the History.txt file
-4. Push to your branch - `git push origin my_branch`
-5. Send me a pull-request for your topic branch
-6. That's it!
+Have a quick look at our [Contribution Guidelines](CONTRIBUTING.md)
+and hack away.
 
 [yasnippet]:http://code.google.com/p/yasnippet/
 [company-mode]:http://nschum.de/src/emacs/company-mode/


### PR DESCRIPTION
I extracted the contribution guidelines into a separate file, which is recognized by github.
