### PR TITLE
Update company-mode backend

### DIFF
--- a/company-emacs-eclim.el
+++ b/company-emacs-eclim.el
@@ -43,6 +43,7 @@
   "A `company-mode' back-end for eclim completion"
   (interactive (list 'interactive))
   (case command
+    (interactive (company-begin-backend 'company-emacs-eclim))
     (prefix
      (let ((start (eclim-completion-start)))
        (when start (buffer-substring-no-properties start (point)))))


### PR DESCRIPTION
- The Conventions section was inaccurate.
- Called interactively, a backend is supposed to initiate completion.
- Keys in `case` clauses don't need to be quoted.
- Using `company-completion-finished-hook` instead of `post-completion` command
  messed up completion with other back-ends.
- The `crop` command is new (added in company-mode 0.6.1), it makes sure that
  `company-complete-common` won't complete too far (it can insert the opening
  bracket and some function arguments otherwise). Users of the previous versions
  just won't receive this benefit.

This more or less brings it to feature parity with the current built-it Eclim backend.
