### PR TITLE
Make interactive version of eclim-java-correct detect line/column

### DIFF
--- a/eclim-java.el
+++ b/eclim-java.el
@@ -496,7 +496,7 @@ method."
 
 (defun eclim-java-correct (line offset)
   "Must be called with the problematic file opened in the current buffer."
-  (interactive)
+  (interactive (list (line-number-at-pos) (current-column)))
   (message "Getting corrections...")
   (eclim/with-results correction-info ("java_correct" "-p" "-f" ("-l" line) ("-o" offset))
     (let ((window-config (current-window-configuration))


### PR DESCRIPTION
While fumbling around, I found running `M-x eclim-java-correct` to bomb out with a message about an invalid number of arguments. I'm not necessarily certain that this function should be interactive, but if it's going to show up in completion results, it might as well pick a line and column for you.
