### PR TITLE
Fix for linked external sources.

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -26,3 +26,7 @@
    than futz with matching dir names to workspace names.
  * Added eclim-eclipse-dirs which can be used if eclipse is not
    installed in the standard location
+ * Changed eclim--project-name to get the project name out of
+   project_by_resource command, and eclim--project-current-file to use
+   project_link_resource command, so that external source files not in the
+   eclipse working directory are correctly handled.


### PR DESCRIPTION
Changed eclim--project-name to get the project name out of project_by_resource command, and eclim--project-current-file to use project_link_resource command, so that external source files not in the eclipse working directory are correctly handled.
