### PR TITLE
Corrected problem with symbolic links

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -30,3 +30,4 @@
    project_by_resource command, and eclim--project-current-file to use
    project_link_resource command, so that external source files not in the
    eclipse working directory are correctly handled.
+ * fixed a problem with highlighting when files are in directories that are symbolic links

--- a/eclim-problems.el
+++ b/eclim-problems.el
@@ -167,7 +167,7 @@
     (widen)
     (when (eclim--file-managed-p)
       (eclim--problems-clear-highlights)
-      (loop for problem across (remove-if-not (lambda (p) (string= (assoc-default 'filename p) (buffer-file-name))) eclim--problems-list)
+      (loop for problem across (remove-if-not (lambda (p) (string= (assoc-default 'filename p) (file-truename (buffer-file-name)))) eclim--problems-list)
             do (eclim--problems-insert-highlight problem)))))
 
 (defun eclim--problems-get-current-problem ()
@@ -184,7 +184,7 @@
         (widen)
         (let ((line (line-number-at-pos))
               (col (current-column)))
-          (or (find-if (lambda (p) (and (string= (assoc-default 'filename p) (buffer-file-name))
+          (or (find-if (lambda (p) (and (string= (assoc-default 'filename p) ((file-truename buffer-file-name)))
                                         (= (assoc-default 'line p) line)))
                        eclim--problems-list)
               (error "No problem on this line")))))))


### PR DESCRIPTION
The highlighting does not work when a file is located in directory that is symbolic link. The following small code changes fixes issue for me.
