### PR TITLE
fix bug:(buffer-file-name) may return null.

### DIFF
--- a/eclim.el
+++ b/eclim.el
@@ -366,7 +366,7 @@ FILENAME is given, return that file's  project name instead."
 
 (defun eclim--find-file (path-to-file)
   (if (not (string-match-p "!" path-to-file))
-      (unless (string= (file-truename path-to-file) (file-truename (buffer-file-name)))
+      (unless (and (buffer-file-name) (file-equal-p path-to-file (buffer-file-name)))
         (find-file-other-window path-to-file))
     (let* ((parts (split-string path-to-file "!"))
            (archive-name (replace-regexp-in-string eclim--compressed-urls-regexp "" (first parts)))


### PR DESCRIPTION
If (buffer-file-name) returns null,then lisp function "eclim--find-file" will raise an error.
It's a serious bug and will make multiple selection all failed.
