### PR TITLE
Corrected custom file path change

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,14 +57,12 @@ If you want to control eclimd from emacs, also add:
 
 Emacs-eclim tries its best to locate your Eclipse installation.  If
 you have Eclipse installed in a non-standard location
-(i.e. ~/opt/eclipse) you have two options:
-
-* Either customize the `eclim-executable` variable to make it point to the `eclim` executable within the Eclipe directory if necessary
-* Or, you can override the lookup by adding the following to your startup script.
+(i.e. ~/nonStandard/eclipse or /opt/eclipse) you may specify the paths manually by adding this to your startup script:
 
 ```lisp
 (custom-set-variables
- '(eclim-eclipse-dirs '("~/opt/eclipse")))
+  '(eclim-eclipse-dirs "~/nonStandard/eclipse")
+  '(eclim-executable "~/nonStandard/eclipse/eclim"))
 ```
 
 ### Displaying compilation error messages in the echo area


### PR DESCRIPTION
Readme tells to set custom variables with
(custom-set-variables
  '(eclim-eclipse-dirs '("~/opt/eclipse")
but should be set like this:
(custom-set-variables
'(eclim-eclipse-dirs "path-to-dir"))
(this leads to the problem that this person had: https://github.com/senny/emacs-eclim/issues/104 )
Also, it is quite misleading to put a tilde before the opt, as most people probably installs eclipse in /opt (not ~/opt).

And lastly, if specifying the eclipse path is supposed to make emacs-eclim find the eclim-executable automatically, I believe it doesn't work, therefore I added setting both variables in the readme.
