### PR TITLE
Resolve #143, Groovy support for emacs-eclim.

### DIFF
--- a/ac-emacs-eclim-source.el
+++ b/ac-emacs-eclim-source.el
@@ -69,6 +69,8 @@
 
 (defun ac-emacs-eclim-config ()
   (add-hook 'java-mode-hook 'ac-emacs-eclim-java-setup)
+  (add-hook 'groovy-mode-hook '(lambda() (interactive)
+                                 (add-to-list 'ac-sources 'ac-source-emacs-eclim)))
   (add-hook 'xml-mode-hook 'ac-emacs-eclim-xml-setup)
   (add-hook 'nxml-mode-hook 'ac-emacs-eclim-xml-setup)
   (add-hook 'php-mode-hook 'ac-emacs-eclim-php-setup)

--- a/company-emacs-eclim.el
+++ b/company-emacs-eclim.el
@@ -66,7 +66,7 @@
     (meta (eclim--completion-documentation
            (concat arg (company-emacs-eclim--annotation arg))))
     (no-cache (equal arg ""))
-    (ignore-case t)
+    (ignore-case nil)
     (sorted t)
     (post-completion (let ((ann (company-emacs-eclim--annotation arg)))
                        (when ann (insert ann))

--- a/eclim-completion.el
+++ b/eclim-completion.el
@@ -60,6 +60,8 @@
                               (eclim/execute-command "java_complete" "-p" "-f" "-e" ("-l" "standard") "-o")))
               ((xml-mode nxml-mode)
                (eclim/execute-command "xml_complete" "-p" "-f" "-e" "-o"))
+              (groovy-mode
+               (eclim/execute-command "groovy_complete" "-p" "-f" "-e" ("-l" "standard") "-o"))
               (ruby-mode
                (eclim/execute-command "ruby_complete" "-p" "-f" "-e" "-o"))
               (php-mode
@@ -155,7 +157,7 @@ buffer."
   (setq eclim--completion-start
         (save-excursion
           (case major-mode
-            ((java-mode javascript-mode js-mode ruby-mode php-mode c-mode c++-mode)
+            ((java-mode javascript-mode js-mode ruby-mode groovy-mode php-mode c-mode c++-mode)
              (progn
                (ignore-errors (beginning-of-thing 'symbol))
                ;; Completion candidates for annotations don't include '@'.
@@ -212,6 +214,7 @@ buffer."
 (defun eclim--completion-action ()
   (case major-mode
     ('java-mode (eclim--completion-action-java))
+    ('groovy-mode (eclim--completion-action-java))
     ((c-mode c++-mode) (eclim--completion-action-java))
     ('nxml-mode (eclim--completion-action-xml))
     (t (eclim--completion-action-default))))

--- a/eclim-java.el
+++ b/eclim-java.el
@@ -120,6 +120,15 @@ Java documentation under Android docs, so don't forget to set
 
 (defvar eclim--is-completing nil)
 
+(defun eclim/groovy-src-update (&optional save-others)
+  "If `eclim-auto-save' is non-nil, save the current java
+ buffer. In addition, if `save-others' is non-nil, also save any
+ other unsaved buffer. Finally, tell eclim to update its java
+ sources."
+  (when eclim-auto-save
+    (when (buffer-modified-p) (save-buffer)) ;; auto-save current buffer, prompt on saving others
+    (when save-others (save-some-buffers nil (lambda () (string-match "\\.groovy$" (buffer-file-name)))))))
+
 (defun eclim/java-src-update (&optional save-others)
   "If `eclim-auto-save' is non-nil, save the current java
 buffer. In addition, if `save-others' is non-nil, also save any

--- a/eclim-problems.el
+++ b/eclim-problems.el
@@ -198,8 +198,8 @@
 (defun eclim-problems-correct ()
   (interactive)
   (let ((p (eclim--problems-get-current-problem)))
-    (if (not (string-match "\.java$" (cdr (assoc 'filename p))))
-        (error "Not a Java file. Corrections are currently supported only for Java.")
+    (if (not (string-match "\\.\\(groovy\\|java\\)$" (cdr (assoc 'filename p))))
+        (error "Not a Java or Groovy file. Corrections are currently supported only for Java or Groovy.")
       (eclim-problems-open-current)
       (eclim-java-correct (cdr (assoc 'line p)) (eclim--byte-offset)))))
 

--- a/eclim.el
+++ b/eclim.el
@@ -168,6 +168,7 @@ where <encoding> is the corresponding java name for this encoding." e e)))
              ((string-match "No command '\\(.*\\)' found" result)
               (let ((c (assoc-default (match-string 1 result)
                                       '(("xml_complete" "XML" "Eclipse Web Developer Tools")
+                                        ("groovy_complete" "Groovy" "Eclipse Groovy Development Tools")
                                         ("ruby_complete" "Ruby" "Eclipse Ruby Development Tools")
                                         ("c_complete" "C/C++" "Eclipse C/C++ Development Tools")
                                         ("php_complete" "PHP" "Eclipse PHP Development Tools")))))
@@ -474,7 +475,7 @@ FILENAME is given, return that file's  project name instead."
     (remove-hook 'after-save-hook 'eclim--after-save-hook 't)))
 
 (defcustom eclim-accepted-file-regexps
-  '("\\.java" "\\.js" "\\.xml" "\\.rb" "\\.php" "\\.c" "\\.cc" "\\.h")
+  '("\\.java" "\\.js" "\\.xml" "\\.rb" "\\.groovy" "\\.php" "\\.c" "\\.cc" "\\.h")
   "List of regular expressions that are matched against filenames
 to decide if eclim should be automatically started on a
 particular file. By default all files part of a project managed
@@ -508,8 +509,10 @@ the use of eclim to java and ant files."
       (apply 'eclim--call-process
              (case major-mode
                (java-mode "java_src_update")
+               (groovy-mode "groovy_src_update")
                (ruby-mode "ruby_src_update")
                (php-mode "php_src_update")
+               
                ((c-mode c++-mode) "c_src_update")
                ((javascript-mode js-mode) "javascript_src_update"))
              (eclim--expand-args (list "-p" "-f")))))


### PR DESCRIPTION
Additional setup to enable eclim in Groovy mode.

```
(add-hook 'groovy-mode-hook     
          (lambda ()     
            (interactive)           
            (progn                                                  
              (remove 'ac-source-clang 'ac-sources)
              (eclim-mode t)))) 
```