### PR TITLE
Don't delay Emacs when Eclim is not running

### DIFF
--- a/eclim-problems.el
+++ b/eclim-problems.el
@@ -212,6 +212,9 @@ it asynchronously."
        (when (not (minibuffer-window-active-p (minibuffer-window)))
          (message "refreshing... %s " (current-buffer)))
        (eclim/with-results-async ,res ("problems" ("-p" eclim--problems-project) (when (string= "e" eclim--problems-filter) '("-e" "true")))
+         (loop for problem across ,res
+               do (let ((filecell (assq 'filename problem)))
+                    (when filecell (setcdr filecell (file-truename (cdr filecell))))))
          (setq eclim--problems-list ,res)
          (let ((,problems ,res))
            ,@body)))))

--- a/eclim-problems.el
+++ b/eclim-problems.el
@@ -163,9 +163,9 @@
 
 (defun eclim-problems-highlight ()
   (interactive)
-  (save-restriction
-    (widen)
-    (when (eclim--file-managed-p)
+  (when (eclim--accepted-p (buffer-file-name))
+    (save-restriction
+      (widen)
       (eclim--problems-clear-highlights)
       (loop for problem across (remove-if-not (lambda (p) (string= (assoc-default 'filename p) (file-truename (buffer-file-name)))) eclim--problems-list)
             do (eclim--problems-insert-highlight problem)))))

--- a/eclim.el
+++ b/eclim.el
@@ -498,8 +498,8 @@ the use of eclim to java and ant files."
   "Return t if and only if eclim should be automatically started on filename."
   (and
    filename
-   (eclim--file-managed-p filename)
-   (eclim--accepted-filename-p filename)))
+   (eclim--accepted-filename-p filename)
+   (eclim--file-managed-p filename)))
 
 ;; Request an eclipse source update when files are saved
 (defun eclim--after-save-hook ()


### PR DESCRIPTION
Without this, find-file and switch-buffer take ages on Windows; fix problem highlighting as well

* eclim-problems-highlight: Change eclim--file-managed-p to eclim--accepted-p, move outside save-restriction

* eclim--accepted-p: Check for accepted filename before trying to execute an eclim process; this is
  significantly less expensive

* eclim--with-problems-list: Normalize filenames in "problems" output, since drive letter comes back in wrong case on Windows