### PR TITLE
Check if eclim should be used for completion in company-emacs-eclim

### DIFF
--- a/company-emacs-eclim.el
+++ b/company-emacs-eclim.el
@@ -59,7 +59,9 @@
   (interactive (list 'interactive))
   (case command
     (interactive (company-begin-backend 'company-emacs-eclim))
-    (prefix (let ((start (eclim-completion-start)))
+    (prefix (let ((start (and eclim-mode
+			      (eclim--accepted-p (buffer-file-name))
+			      (eclim-completion-start))))
               (when start (buffer-substring-no-properties start (point)))))
     (candidates (company-emacs-eclim--candidates arg))
     (annotation (company-emacs-eclim--annotation arg))


### PR DESCRIPTION
The prefix command should return nil if the back end isn't able to generate a completion. This pull request adds tests which will only attempt to generate completions if eclim-mode is active and the file is part of a project managed by eclim.

The current behavior will return a non-nil result for any mode that can possibly be supported, regardless of whether eclimd is running or if there is a project for this file. This has the effect of blocking other completion backends from handling completion, even though eclim will never be able to generate a completion.