### PR TITLE
Set line-move-visual as buffer local variable

### DIFF
--- a/eclim-problems.el
+++ b/eclim-problems.el
@@ -80,9 +80,9 @@
         mode-name "eclim/problems"
         mode-line-process ""
         truncate-lines t
-        line-move-visual nil
         buffer-read-only t
         default-directory (eclim/workspace-dir))
+  (setq-local line-move-visual nil)
   (setq mode-line-format
         (list "-"
               'mode-line-mule-info


### PR DESCRIPTION
`eclim--problems-mode` currently globally sets `line-move-visual` to `nil`. This changes emacs behavior in all other buffers and overrides any user preferences. This pull request sets that variable as a buffer local variable when `eclim--problems-mode` is enabled. Only the assignment to `line-move-visual` was changed because all of the other variables set by `eclim--problems-mode` automatically become buffer local when set.