### PR TITLE
Significantly improved performance by removing 1 symlink check

### DIFF
--- a/eclim-problems.el
+++ b/eclim-problems.el
@@ -158,7 +158,7 @@
     (save-restriction
       (widen)
       (eclim--problems-clear-highlights)
-      (loop for problem across (remove-if-not (lambda (p) (string= (assoc-default 'filename p) (file-truename (buffer-file-name)))) eclim--problems-list)
+      (loop for problem across (remove-if-not (lambda (p) (string= (assoc-default 'filename p) (buffer-file-name))) eclim--problems-list)
             do (eclim--problems-insert-highlight problem)))))
 
 (defadvice find-file (after eclim-problems-highlight-on-find-file activate)


### PR DESCRIPTION
Emacs was constantly consuming 100% CPU whenever opening a new file
with many problems. The reason I found, by the use of profiler-report,
was in eclim-problems-highlight where an extra call to file-truename
was made to resolve any symlinks in the path to the Java at hand.

This change was introduced in b0368df2 to fix the handling of
symlinks, but it makes Emacs/eclim unusuable for me on large projects
where Emacs spends ~8 seconds to switch to an already opened Java
file while always hitting 100% CPU usage.

With this wee change, Emacs opens & switches to Java-buffers
instantaneously and CPU normally doesn't go above 5% for the same
opening of a Java file and decoration of errors in that buffer.

In case anyone is interested: My system: GNU Emacs 24.4.1, Debian
Jessie, Intel i7 CPU, 8 GB. Number of Java files in project 1032. 
Number of eclim problems: 10240

There's probably smarter fixes for this problem, but the change is small
and it makes a big difference for me, so I'll stick with it for sure. Created 
the PR in case others want it too.

Cheers,

-Torstein