### PR TITLE
Added support for running JUnit class or method at point

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -18,7 +18,8 @@
  * eclimd module to start/stop eclimd from emacs
  * Generation of getter and setter methods.
  * User commands for adding, listing and removing project natures.
- 
+ * Running all JUnit tests in a class or just the test method at point.
+
 === Bugfixes
  * removed extra parentheses around function
  * fixed a problem on startup when the eclimd server was not started

--- a/eclim-java.el
+++ b/eclim-java.el
@@ -41,6 +41,7 @@
 (define-key eclim-mode-map (kbd "C-c C-e d") 'eclim-java-doc-comment)
 (define-key eclim-mode-map (kbd "C-c C-e f s") 'eclim-java-format)
 (define-key eclim-mode-map (kbd "C-c C-e g") 'eclim-java-generate-getter-and-setter)
+(define-key eclim-mode-map (kbd "C-c C-e t") 'eclim-run-junit)
 
 (defvar eclim-java-show-documentation-map
   (let ((map (make-keymap)))
@@ -560,6 +561,24 @@ method."
     (compile (concat eclim-executable " -command java -p "  eclim--project-name
                      " -c " (eclim-package-and-class)))))
 
+(defun eclim-run-junit (project file offset encoding)
+  "Run the current JUnit class or method at point.
+
+This method hooks onto the running Eclipse process and is thus
+much faster than running mvn test -Dtest=TestClass#method."
+  (interactive (list (eclim--project-name)
+                     (eclim--project-current-file)
+                     (eclim--byte-offset)
+                     (eclim--current-encoding)))
+  (if (not (string= major-mode "java-mode"))
+      (message "Running JUnit tests only makes sense for Java buffers.")
+    (compile
+     (concat eclim-executable
+             " -command java_junit -p " project
+             " -f " file
+             " -o " (number-to-string offset)
+             " -e " encoding))))
+
 (defun eclim-java-correct (line offset)
   "Must be called with the problematic file opened in the current buffer."
   (message "Getting corrections...")
@@ -737,6 +756,5 @@ method."
   (erase-buffer)
   (insert (pop eclim-java-show-documentation-history))
   (goto-char (point-min)))
-
 
 (provide 'eclim-java)


### PR DESCRIPTION
As a side note: I'm positively surprised of the speed boost using eclim/java_junit is, 
it is much faster than running mvn test -Dtest=TestClass#method 
since it doesn't have to start a new JVM. Logical, but still a nice plus.

Cheers,

-Torstein