### PR TITLE
Better modeline string with info about problems

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -18,7 +18,8 @@
  * eclimd module to start/stop eclimd from emacs
  * Generation of getter and setter methods.
  * User commands for adding, listing and removing project natures.
- 
+ * additional info in modeline about errors and warnings
+
 === Bugfixes
  * removed extra parentheses around function
  * fixed a problem on startup when the eclimd server was not started

--- a/eclim-problems.el
+++ b/eclim-problems.el
@@ -273,7 +273,7 @@ it asynchronously."
           (goto-char (point-min))
           (forward-line (1- line-number)))))))
 
-(defun eclim--problems-filtered (&optional ignore-type-filter)
+(defun eclim--problems-filtered ()
   "Filter reported problems by eclim.
 
 It filters out problems using the ECLIM--PROBLEMS-FILEFILTER
@@ -282,17 +282,29 @@ are also filtered according to ECLIM--PROBLEMS-FILTER, i.e.,
 error type. Otherwise, error type is ignored. This is useful when
 other mechanisms, like compilation's mode
 COMPILATION-SKIP-THRESHOLD, implement this feature."
-  (remove-if-not
-   (lambda (x) (and
-                (or (not eclim--problems-filefilter)
-                    (string= (assoc-default 'filename x) eclim--problems-file))
-                (or ignore-type-filter
-                    (not eclim--problems-filter)
-                    (and (string= "e" eclim--problems-filter)
-                         (not (eq t (assoc-default 'warning x))))
-                    (and (string= "w" eclim--problems-filter)
-                         (eq t (assoc-default 'warning x))))))
-   eclim--problems-list))
+  (eclim--filter-problems eclim--problems-filter eclim--problems-filefilter eclim--problems-file eclim--problems-list))
+
+(defun eclim--warning-filterp (x)
+  (eq t (assoc-default 'warning x)))
+
+(defun eclim--error-filterp (x)
+  (not (eclim--warning-filterp x)))
+
+(defun eclim--choose-type-filter (type-filter)
+  (cond
+   ((not type-filter) '(lambda (_) t))
+   ((string= "e" type-filter) 'eclim--error-filterp)
+   (t 'eclim--warning-filterp)))
+
+(defun eclim--choose-file-filter (file-filter file)
+  (if (not file-filter)
+      '(lambda (_) t)
+    '(lambda (x) (string= (assoc-default 'filename x) file))))
+
+(defun eclim--filter-problems (type-filter file-filter file problems)
+  (let ((type-filterp (eclim--choose-type-filter type-filter))
+        (file-filterp (eclim--choose-file-filter file-filter file)))
+    (remove-if-not (lambda (x) (and (funcall type-filterp x) (funcall file-filterp x))) problems)))
 
 (defun eclim--insert-problem (problem filecol-size)
   (let* ((filecol-format-string (concat "%-" (number-to-string filecol-size) "s"))
@@ -444,5 +456,20 @@ is convenient as it lets the user navigate between errors using
     (let ((line (assoc-default 'line problem))
           (col (assoc-default 'column problem)))
       (insert (format "%s:%s:%s: %s: %s\n" filename line col (upcase type) description)))))
+
+(defun eclim--count-current-errors ()
+  (length
+   (eclim--filter-problems "e" t (buffer-file-name (current-buffer)) eclim--problems-list)))
+
+(defun eclim--count-current-warnings ()
+  (length
+   (eclim--filter-problems "w" t (buffer-file-name (current-buffer)) eclim--problems-list)))
+
+(defun eclim-problems-modeline-string ()
+  "Returns modeline string with additional info about
+problems for current file"
+  (concat (format " : %s/%s"
+                  (eclim--count-current-errors)
+                  (eclim--count-current-warnings))))
 
 (provide 'eclim-problems)

--- a/eclim.el
+++ b/eclim.el
@@ -431,8 +431,8 @@ FILENAME is given, return that file's  project name instead."
 (defun eclim-file-locate (pattern &optional case-insensitive)
   (interactive (list (read-string "Pattern: ") "P"))
   (eclim/with-results hits ("locate_file" ("-p" (concat "^.*" pattern ".*$")) ("-s" "workspace") (if case-insensitive '("-i" "")))
-    (eclim--find-display-results pattern 
-                                 (apply #'vector 
+    (eclim--find-display-results pattern
+                                 (apply #'vector
                                         (mapcar (lambda (hit) (list (cons 'filename (assoc-default 'path hit))
                                                                     (cons 'line 1)
                                                                     (cons 'column 1)
@@ -512,7 +512,7 @@ the use of eclim to java and ant files."
                (groovy-mode "groovy_src_update")
                (ruby-mode "ruby_src_update")
                (php-mode "php_src_update")
-               
+
                ((c-mode c++-mode) "c_src_update")
                ((javascript-mode js-mode) "javascript_src_update"))
              (eclim--expand-args (list "-p" "-f")))))
@@ -543,5 +543,12 @@ the use of eclim to java and ant files."
 (require 'eclim-ant)
 (require 'eclim-maven)
 (require 'eclim-problems)
+
+(add-to-list 'minor-mode-alist
+             '(eclim-mode (:eval (eclim-modeline-string))))
+
+(defun eclim-modeline-string ()
+  (when eclim-mode
+    (concat "Eclim " (eclim-problems-modeline-string))))
 
 (provide 'eclim)


### PR DESCRIPTION
I was impressed when I used ensime couple weeks ago. One of the nice features was information about number of errors and warning in modeline string. This is the same just implemented for eclim. 

To easily achieve this I needed to rewrite function that was filtering problems. On the surface it's working mostly the same (I dropped unused `ignore-type-filter`). Under the hood there's another function that is doing all heavy-lifting -  `eclim--filter-problems` - which depends only on input parameters.