### PR TITLE
Make the length of error highlight display to min 1.

### DIFF
--- a/eclim-problems.el
+++ b/eclim-problems.el
@@ -140,7 +140,7 @@
     (eclim--problem-goto-pos problem)
     (let* ((id (eclim--java-identifier-at-point t t))
            (start (car id))
-           (end (+ (car id) (length (cdr id)))))
+           (end (+ (car id) (max 1 (length (cdr id))))))
       (let ((highlight (make-overlay start end (current-buffer) t t)))
         (overlay-put highlight 'face
                      (if (eq t (assoc-default 'warning problem))


### PR DESCRIPTION
In cases when the there is no java symbol under the cursor, this turns out to be zero and the error highlight cannot be seen.