### PR TITLE
Using popup.el for eclim-problems-correct

### DIFF
--- a/eclim-java.el
+++ b/eclim-java.el
@@ -545,11 +545,12 @@ method."
 
 (defun eclim-java-correct (line offset)
   (eclim/with-results correction-info ("java_correct" "-p" "-f" ("-l" line) ("-o" offset))
-    (let ((corrections (cdr (assoc 'corrections correction-info)))
-          (cmenu (list)))
-      (if (eq (length corrections) 0)
-          (message "No automatic corrections found. Sorry."))
-
+    (if (stringp correction-info)
+        (message correction-info)
+      (let ((corrections (cdr (assoc 'corrections correction-info)))
+            (cmenu (list)))
+        (if (eq (length corrections) 0)
+            (message "No automatic corrections found. Sorry."))
         (dotimes (i (length corrections))
           (let ((correction (aref corrections i)))
             (setq cmenu
@@ -567,7 +568,7 @@ method."
                "-f"
                ("-l" line)
                ("-o" offset)
-               ("-a" choice))))))))
+               ("-a" choice)))))))))
 
 (defun eclim-java-show-documentation-for-current-element ()
   "Displays the doc comments for the element at the pointers position."

--- a/eclim-java.el
+++ b/eclim-java.el
@@ -101,23 +101,6 @@ Java documentation under Android docs, so don't forget to set
                                       "implementors"
                                       "references"))
 
-(defvar eclim-java-correct-map
-  (let ((map (make-keymap)))
-    (suppress-keymap map t)
-    (define-key map (kbd "q") 'eclim-java-correct-quit)
-    (define-key map (kbd "0") 'eclim-java-correct-choose-by-digit)
-    (define-key map (kbd "1") 'eclim-java-correct-choose-by-digit)
-    (define-key map (kbd "2") 'eclim-java-correct-choose-by-digit)
-    (define-key map (kbd "3") 'eclim-java-correct-choose-by-digit)
-    (define-key map (kbd "4") 'eclim-java-correct-choose-by-digit)
-    (define-key map (kbd "5") 'eclim-java-correct-choose-by-digit)
-    (define-key map (kbd "6") 'eclim-java-correct-choose-by-digit)
-    (define-key map (kbd "7") 'eclim-java-correct-choose-by-digit)
-    (define-key map (kbd "8") 'eclim-java-correct-choose-by-digit)
-    (define-key map (kbd "9") 'eclim-java-correct-choose-by-digit)
-    (define-key map (kbd "RET") 'eclim-java-correct-choose)
-    map))
-
 (defvar eclim--is-completing nil)
 
 (defun eclim/groovy-src-update (&optional save-others)
@@ -561,79 +544,30 @@ method."
                      " -c " (eclim-package-and-class)))))
 
 (defun eclim-java-correct (line offset)
-  "Must be called with the problematic file opened in the current buffer."
-  (message "Getting corrections...")
   (eclim/with-results correction-info ("java_correct" "-p" "-f" ("-l" line) ("-o" offset))
-    (let ((window-config (current-window-configuration))
-          (corrections (cdr (assoc 'corrections correction-info)))
-          (project (eclim--project-name))) ;; store project name before buffer change
-      (pop-to-buffer "*corrections*")
-      (erase-buffer)
-      (use-local-map eclim-java-correct-map)
-
-      (insert "Problem: " (cdr (assoc 'message correction-info)) "\n\n")
+    (let ((corrections (cdr (assoc 'corrections correction-info)))
+          (cmenu (list)))
       (if (eq (length corrections) 0)
-          (insert "No automatic corrections found. Sorry.")
-        (insert (substitute-command-keys
-                 (concat
-                  "Choose a correction by pressing \\[eclim-java-correct-choose]"
-                  " on it or typing its index. Press \\[eclim-java-correct-quit] to quit"))))
-      (insert "\n\n")
+          (cons cmenu '("No automatic corrections found. Sorry."))
 
-      (dotimes (i (length corrections))
-        (let ((correction (aref corrections i)))
-          (insert "------------------------------------------------------------\n"
-                  "Correction "
-                  (int-to-string (cdr (assoc 'index correction)))
-                  ": " (cdr (assoc 'description correction)) "\n\n"
-                  "Preview:\n\n"
-                  (cdr (assoc 'preview correction))
-                  "\n\n")))
-      (goto-char (point-min))
-      (make-local-variable 'eclim-corrections-previous-window-config)
-      (setq eclim-corrections-previous-window-config window-config)
-      (make-local-variable 'eclim-correction-command-info)
-      (setq eclim-correction-command-info (list 'project project
-                                                'line line
-                                                'offset offset)))))
-
-(defun eclim-java-correct-choose (&optional index)
-  (interactive)
-  (save-excursion
-    (if index
-        (goto-char (point-max)))
-    (if (not (re-search-backward (concat "^Correction "
-                                         (if index
-                                             index
-                                           "\\([0-9]+\\)")
-                                         ":")
-                                 nil t))
-        (message (concat "No correction "
-                         (if index
-                             (format "with index %s." index)
-                           "here.")))
-      (unless index
-        (setq index (string-to-int (match-string 1))))
-      (let ((info eclim-correction-command-info))
-        (set-window-configuration eclim-corrections-previous-window-config)
-        (message "Applying correction %s" index)
-        (eclim/with-results correction-info ("java_correct"
-                                             ("-p" (plist-get info 'project))
-                                             "-f"
-                                             ("-l" (plist-get info 'line))
-                                             ("-o" (plist-get info 'offset))
-                                             ("-a" index))
-          (eclim--problems-update-maybe))))))
-
-(defun eclim-java-correct-choose-by-digit ()
-  (interactive)
-  (eclim-java-correct-choose (this-command-keys)))
-
-
-(defun eclim-java-correct-quit ()
-  (interactive)
-  (set-window-configuration eclim-corrections-previous-window-config))
-
+        (dotimes (i (length corrections))
+          (let ((correction (aref corrections i)))
+            (setq cmenu
+                  (cons
+                   (popup-make-item
+                    (cdr (assoc 'description correction))
+                    :value i
+                    :document (cdr (assoc 'preview correction)))
+                   cmenu))))
+        (let ((choice (popup-menu* (reverse cmenu))))
+          (when choice
+            (eclim/with-results correction-info
+              ("java_correct"
+               ("-p" eclim--project-name)
+               "-f"
+               ("-l" line)
+               ("-o" offset)
+               ("-a" choice)))))))))
 
 (defun eclim-java-show-documentation-for-current-element ()
   "Displays the doc comments for the element at the pointers position."

--- a/eclim-java.el
+++ b/eclim-java.el
@@ -548,7 +548,7 @@ method."
     (let ((corrections (cdr (assoc 'corrections correction-info)))
           (cmenu (list)))
       (if (eq (length corrections) 0)
-          (cons cmenu '("No automatic corrections found. Sorry."))
+          (message "No automatic corrections found. Sorry."))
 
         (dotimes (i (length corrections))
           (let ((correction (aref corrections i)))
@@ -567,7 +567,7 @@ method."
                "-f"
                ("-l" line)
                ("-o" offset)
-               ("-a" choice)))))))))
+               ("-a" choice))))))))
 
 (defun eclim-java-show-documentation-for-current-element ()
   "Displays the doc comments for the element at the pointers position."

--- a/eclim-java.el
+++ b/eclim-java.el
@@ -547,20 +547,17 @@ method."
   (eclim/with-results correction-info ("java_correct" "-p" "-f" ("-l" line) ("-o" offset))
     (if (stringp correction-info)
         (message correction-info)
-      (let ((corrections (cdr (assoc 'corrections correction-info)))
-            (cmenu (list)))
+      (let ((corrections (cdr (assoc 'corrections correction-info))))
         (if (eq (length corrections) 0)
             (message "No automatic corrections found. Sorry."))
-        (dotimes (i (length corrections))
-          (let ((correction (aref corrections i)))
-            (setq cmenu
-                  (cons
-                   (popup-make-item
-                    (cdr (assoc 'description correction))
-                    :value i
-                    :document (cdr (assoc 'preview correction)))
-                   cmenu))))
-        (let ((choice (popup-menu* (reverse cmenu))))
+        (setq-local cmenu
+                    (mapcar (lambda (correction)
+                              (popup-make-item
+                               (cdr (assoc 'description correction))
+                               :value (cdr (assoc 'index correction))
+                               :document (cdr (assoc 'preview correction))))
+                            corrections))
+        (let ((choice (popup-menu* cmenu)))
           (when choice
             (eclim/with-results correction-info
               ("java_correct"

--- a/eclim-problems.el
+++ b/eclim-problems.el
@@ -200,7 +200,6 @@
   (let ((p (eclim--problems-get-current-problem)))
     (if (not (string-match "\\.\\(groovy\\|java\\)$" (cdr (assoc 'filename p))))
         (error "Not a Java or Groovy file. Corrections are currently supported only for Java or Groovy.")
-      (eclim-problems-open-current)
       (eclim-java-correct (cdr (assoc 'line p)) (eclim--byte-offset)))))
 
 (defmacro eclim--with-problems-list (problems &rest body)


### PR DESCRIPTION
Running eclim-problems-correct opens up a new buffer with all the suggestions and the user can select one of them.

usually the summay of the suggestion is enough for the user to understand what the correction will do.

Locally, I edited the eclim-problems and eclim-java for providing this and it integrates very smoothly.

The user is provided with a list of suggestions and the he can see the preview with F1.

![nimbus-image-1431930191525](https://cloud.githubusercontent.com/assets/390403/7675314/c6886da6-fceb-11e4-9a9c-1e791978c204.png)

I can send a patch if this is fine.
