### PR TITLE
eclim--project-dir breaks when file is not located in the project root.

### DIFF
--- a/eclim-java.el
+++ b/eclim-java.el
@@ -145,7 +145,7 @@ in eclim when appropriate."
         (fn nil))
     (ignore-errors
       (and (setq pr (eclim--project-name filename))
-           (setq fn (file-relative-name filename (eclim--project-dir filename)))))
+           (setq fn (file-relative-name filename (eclim--project-dir pr)))))
     ad-do-it
     (when (and pr fn)
       (ignore-errors (apply 'eclim--call-process (list "java_src_update" "-p" pr "-f" fn))))))

--- a/eclim.el
+++ b/eclim.el
@@ -334,14 +334,10 @@ value is computed for that file's instead."
       (and file
            (eclim--project-name file)))))
 
-(defun eclim--project-dir (&optional filename)
+(defun eclim--project-dir (&optional projectname)
   "Return this file's project root directory. If the optional
-argument FILENAME is given, return that file's project root directory."
-  (let ((root (locate-dominating-file (or filename buffer-file-name) ".project")))
-    (when root
-      (directory-file-name
-       (file-name-directory
-        (expand-file-name root))))))
+argument PROJECTNAME is given, return that project's root directory."
+  (assoc-default 'path (eclim/project-info (or projectname (eclim--project-name)))))
 
 (defun eclim--project-name (&optional filename)
   "Returns this file's project name. If the optional argument
@@ -535,7 +531,7 @@ the use of eclim to java and ant files."
   (lambda ()
     (if (and buffer-file-name
              (eclim--accepted-p buffer-file-name)
-             (eclim--project-dir buffer-file-name))
+             (eclim--project-dir))
         (eclim-mode 1))))
 
 (require 'eclim-project)

--- a/eclim.el
+++ b/eclim.el
@@ -335,7 +335,7 @@ value is computed for that file's instead."
            (eclim--project-name file)))))
 
 (defun eclim--project-dir (&optional projectname)
-  "Return this file's project root directory. If the optional
+  "Return this project's root directory. If the optional
 argument PROJECTNAME is given, return that project's root directory."
   (assoc-default 'path (eclim/project-info (or projectname (eclim--project-name)))))
 


### PR DESCRIPTION
Its very common to have eclipse projects where the source code is located outside the directory containing the .project file.

eclim--project-dir is using locate-dominating-file which will fail if the file is not in the project root dir.

This breaks problems autoupdate, highlight etc as they are conditioned on eclim--project-dir.
eclim-ant and eclim-maven are also using this function but I dont use either of them so cant tell if they break too.