### PR TITLE
Navigate source code using the existing buffer

### DIFF
--- a/eclim.el
+++ b/eclim.el
@@ -356,7 +356,7 @@ FILENAME is given, return that file's  project name instead."
 (defun eclim--find-file (path-to-file)
   (if (not (string-match-p "!" path-to-file))
       (unless (and (buffer-file-name) (file-equal-p path-to-file (buffer-file-name)))
-        (find-file-other-window path-to-file))
+        (find-file path-to-file))
     (let* ((parts (split-string path-to-file "!"))
            (archive-name (replace-regexp-in-string eclim--compressed-urls-regexp "" (first parts)))
            (file-name (second parts)))


### PR DESCRIPTION
When jumping to the declaration for something, emacs-eclim would open
a new buffer to display the results, e.g. hitting
eclim-java-find-declaration on the "setName" below:

  myObject.setName(name);

would open a new buffer with MyObject.java in it.

I found this behaviour pretty annoying. For starters, it is different
from other Java editing environments, I found it distracting to have to
shift my focus back and forth between 3-4 buffers while navigation to a
given method or mother object.  Lastly, it alters the window layout you
have, displaying the jumped-to file whereever Emacs find logical (for
instance in the horizontally split buffer in the lower part of my Emacs
frame where I like to display compile or junit output).

This wee change makes emacs-eclim open the class holding the
declaration of "MyObject#setName(String) in the same buffer as you
were when hitting eclim-java-find-declaration. This makes IMHO for a
much neater coding experience in alignment with navigation source code
in say IntelliJ IDEA or Eclipse.