### PR TITLE
eclim-problems-open-current - open in same window

### DIFF
--- a/eclim-problems.el
+++ b/eclim-problems.el
@@ -189,11 +189,16 @@
                        eclim--problems-list)
               (error "No problem on this line")))))))
 
-(defun eclim-problems-open-current ()
+(defun eclim-problems-open-current (&optional same-window)
   (interactive)
   (let* ((p (eclim--problems-get-current-problem)))
-    (find-file-other-window (assoc-default 'filename p))
+    (funcall (if same-window
+         'find-file
+       'find-file-other-window)
+     (assoc-default 'filename p))
     (eclim--problem-goto-pos p)))
+
+(funcall (if t '+ '-) 1 2)
 
 (defun eclim-problems-correct ()
   (interactive)
@@ -379,7 +384,7 @@ without switching to it."
     (with-current-buffer eclim--problems-buffer-name
       (eclim-problems-buffer-refresh))))
 
-(defun eclim-problems-next ()
+(defun eclim-problems-next (&optional same-window)
   (interactive)
   (let ((prob-buf (get-buffer eclim--problems-buffer-name)))
     (when prob-buf
@@ -388,16 +393,24 @@ without switching to it."
           (setq eclim--problems-list-at-first nil)
         (forward-line 1))
       (hl-line-move hl-line-overlay)
-      (eclim-problems-open-current))))
+      (eclim-problems-open-current same-window))))
 
-(defun eclim-problems-previous ()
+(defun eclim-problems-previous (&optional same-window)
   (interactive)
   (let ((prob-buf (get-buffer eclim--problems-buffer-name)))
     (when prob-buf
       (set-buffer prob-buf)
       (forward-line -1)
       (hl-line-move hl-line-overlay)
-      (eclim-problems-open-current))))
+      (eclim-problems-open-current same-window))))
+
+(defun eclim-problems-next-same-window ()
+  (interactive)
+  (eclim-problems-next t))
+
+(defun eclim-problems-previous-same-window ()
+  (interactive)
+  (eclim-problems-previous t))
 
 (defun eclim--problems-update-maybe ()
   "If autoupdate is enabled, this function triggers a delayed


### PR DESCRIPTION
`eclim-problems-open-current` was used by next/previous
so it now accepts optional flag if problem should be open
in same window.

new functions `eclim-problems-next/previous-same-window`
show next place with problem in current window. That way we can navigate
in similar way to *compilation* buffer but without having
one. 

The problem with current functions `eclim-problems-next` is
that they use `find-file-other-window` under the hood so
they are switching window each time when called from java file.

I was inspired by @skybert yesterday pull https://github.com/senny/emacs-eclim/pull/174.

