### PR TITLE
Regexp was to greedy at the start

### DIFF
--- a/eclim-maven.el
+++ b/eclim-maven.el
@@ -30,7 +30,7 @@
 ;; Add regexp to make compilation-mode understand maven2 errors
 (setq compilation-error-regexp-alist
       (append (list
-               '("^\\(.*\\):\\[\\([0-9]*\\),\\([0-9]*\\)\\]" 1 2 3))
+               '("\\[ERROR]\\ \/\\(.*\\):\\[\\([0-9]*\\),\\([0-9]*\\)]" 1 2 3))
               compilation-error-regexp-alist))
 
 (define-key eclim-mode-map (kbd "C-c C-e m p") 'eclim-maven-lifecycle-phase-run)


### PR DESCRIPTION
I added `/` after `[ERROR]` match to eliminate false positives like this:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.2:compile message
```

Fix #175