### PR TITLE
Add note for prerequisite library 's.el' in manual install instruction

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -20,6 +20,7 @@
  * User commands for adding, listing and removing project natures.
  * Running all JUnit tests in a class or just the test method at point.
  * additional info in modeline about errors and warnings
+ * add note on s.el prerequisites
 
 === Bugfixes
  * removed extra parentheses around function

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ number. You can see and download previous releases
    the archive to `package-archives` if you haven't already, and then
    install emacs-eclim with the `package-install` command.
    * Manual installation from GitHub.
+       1. *NOTE:* You'll need the [`s` string manipulation library](https://github.com/magnars/s.el)
        1. (`git clone git://github.com/senny/emacs-eclim.git`)
        1. Add `(add-to-list 'load-path "/path/to/emacs-eclim/")` to your startup script.
 1. Add the following code to your emacs startup script


### PR DESCRIPTION
Running `(require 'eclim)` failed initially for me as eclim.el requires `s.el` which isn't installed by default.
