### PR TITLE
Support for travis-ci

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,3 @@
+((nil . ((indent-tabs-mode . nil)
+         (fill-column . 80)
+         (elisp-lint-ignored-validators . ("package-format")))))

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: java
+cache: apt
+env:
+  - CI=true
+
+install:
+  - sudo add-apt-repository -y ppa:cassou/emacs && sudo apt-get update -qq && sudo apt-get -f install -qq && sudo apt-get install -qq emacs24 emacs24-el
+  - cd /tmp
+  - mkdir /home/travis/opt && wget http://download.eclipse.org/technology/epp/downloads/release/luna/R/eclipse-java-luna-R-linux-gtk-x86_64.tar.gz -O eclipse.tar.gz && tar -xf eclipse.tar.gz -C /home/travis/opt
+  - wget http://sourceforge.net/projects/eclim/files/latest/download -O eclim.jar && java -Dvim.skip=true -Declipse.home=/home/travis/opt/eclipse -jar eclim.jar install
+  - cd - && cd tests && git clone https://github.com/nschum/elisp-lint.git
+  - cd -
+script:
+  - emacs -Q --batch -l tests/emacs-eclim-linter-init.el -f elisp-lint-files-batch *.el
+  - true

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![License GPL 3][badge-license]](http://www.gnu.org/licenses/gpl-3.0.txt)
+[![Build Status](https://travis-ci.org/kleewho/emacs-eclim.svg?branch=travis)](https://travis-ci.org/kleewho/emacs-eclim)
 [![MELPA](http://melpa.org/packages/emacs-eclim-badge.svg)](http://melpa.org/#/emacs-eclim)
 [![MELPA Stable](http://stable.melpa.org/packages/emacs-eclim-badge.svg)](http://stable.melpa.org/#/emacs-eclim)
 

--- a/ac-emacs-eclim-source.el
+++ b/ac-emacs-eclim-source.el
@@ -76,7 +76,8 @@
 (defun ac-emacs-eclim-config ()
   (add-hook 'java-mode-hook 'ac-emacs-eclim-java-setup)
   (add-hook 'groovy-mode-hook '(lambda() (interactive)
-                                 (add-to-list 'ac-sources 'ac-source-emacs-eclim)))
+                                 (add-to-list 'ac-sources
+                                              'ac-source-emacs-eclim)))
   (add-hook 'xml-mode-hook 'ac-emacs-eclim-xml-setup)
   (add-hook 'nxml-mode-hook 'ac-emacs-eclim-xml-setup)
   (add-hook 'php-mode-hook 'ac-emacs-eclim-php-setup)

--- a/company-emacs-eclim.el
+++ b/company-emacs-eclim.el
@@ -38,8 +38,9 @@
   of available company backends."
   (setq company-backends
         (cons 'company-emacs-eclim
-              (remove-if (lambda (b) (find b '(company-nxml company-eclim)))
-                         company-backends))))
+              (cl-remove-if (lambda (b) (cl-find b '(company-nxml
+                                                     company-eclim)))
+                            company-backends))))
 
 (defun company-emacs-eclim--candidates (prefix)
   (mapcar

--- a/eclim-completion.el
+++ b/eclim-completion.el
@@ -57,7 +57,7 @@
             (case major-mode
               (java-mode
                (assoc-default 'completions
-                 (eclim/execute-command "java_complete" "-p" "-f" "-e" ("-l" "standard") "-o")))
+                              (eclim/execute-command "java_complete" "-p" "-f" "-e" ("-l" "standard") "-o")))
               ((xml-mode nxml-mode)
                (eclim/execute-command "xml_complete" "-p" "-f" "-e" "-o"))
               (groovy-mode
@@ -68,7 +68,7 @@
                (eclim/execute-command "php_complete" "-p" "-f" "-e" "-o"))
               ((javascript-mode js-mode)
                (eclim/execute-command "javascript_complete" "-p" "-f" "-e" "-o"))
-              (scala-mode 
+              (scala-mode
                (eclim/execute-command "scala_complete" "-p" "-f" "-e" ("-l" "standard") "-o"))
               ((c++-mode c-mode)
                (eclim/execute-command "c_complete" "-p" "-f" "-e" ("-l" "standard") "-o"))))
@@ -91,7 +91,7 @@ in a completion menu."
   (with-no-warnings
     (remove-if #'eclim--completion-candidates-filter
                (mapcar #'eclim--completion-candidate-menu-item
-               (eclim--complete)))))
+                       (eclim--complete)))))
 
 (defun eclim--basic-complete-internal (completion-list)
   "Displays a buffer of basic completions."

--- a/eclim-maven.el
+++ b/eclim-maven.el
@@ -26,6 +26,7 @@
 ;;* Eclim Maven
 
 (require 'compile)
+(require 'eclim)
 
 ;; Add regexp to make compilation-mode understand maven2 errors
 (setq compilation-error-regexp-alist
@@ -37,7 +38,8 @@
 (define-key eclim-mode-map (kbd "C-c C-e m r") 'eclim-maven-run)
 
 (defvar eclim-maven-lifecycle-phases
-  '("validate" "compile" "test" "package" "integration" "verify" "install" "deploy"))
+  '("validate" "compile" "test" "package"
+    "integration" "verify" "install" "deploy"))
 
 (defun eclim--maven-lifecycle-phase-read ()
   (completing-read "Phase: " eclim-maven-lifecycle-phases))

--- a/eclim-problems.el
+++ b/eclim-problems.el
@@ -51,18 +51,18 @@
 (defvar eclim--problems-project nil) ;; problems are relative to this project
 (defvar eclim--problems-file nil) ;; problems are relative to this file (when eclim--problems-filefilter is non-nil)
 
-(setq eclim-problems-mode-map
-      (let ((map (make-keymap)))
-        (suppress-keymap map t)
-        (define-key map (kbd "a") 'eclim-problems-show-all)
-        (define-key map (kbd "e") 'eclim-problems-show-errors)
-        (define-key map (kbd "g") 'eclim-problems-buffer-refresh)
-        (define-key map (kbd "q") 'eclim-quit-window)
-        (define-key map (kbd "w") 'eclim-problems-show-warnings)
-        (define-key map (kbd "f") 'eclim-problems-toggle-filefilter)
-        (define-key map (kbd "c") 'eclim-problems-correct)
-        (define-key map (kbd "RET") 'eclim-problems-open-current)
-        map))
+(defvar eclim-problems-mode-map
+  (let ((map (make-keymap)))
+    (suppress-keymap map t)
+    (define-key map (kbd "a") 'eclim-problems-show-all)
+    (define-key map (kbd "e") 'eclim-problems-show-errors)
+    (define-key map (kbd "g") 'eclim-problems-buffer-refresh)
+    (define-key map (kbd "q") 'eclim-quit-window)
+    (define-key map (kbd "w") 'eclim-problems-show-warnings)
+    (define-key map (kbd "f") 'eclim-problems-toggle-filefilter)
+    (define-key map (kbd "c") 'eclim-problems-correct)
+    (define-key map (kbd "RET") 'eclim-problems-open-current)
+    map))
 
 (define-key eclim-mode-map (kbd "C-c C-e b") 'eclim-problems)
 (define-key eclim-mode-map (kbd "C-c C-e o") 'eclim-problems-open)
@@ -160,7 +160,7 @@
     (save-restriction
       (widen)
       (eclim--problems-clear-highlights)
-      (loop for problem across (remove-if-not (lambda (p) (string= (assoc-default 'filename p) (buffer-file-name))) eclim--problems-list)
+      (loop for problem across (cl-remove-if-not (lambda (p) (string= (assoc-default 'filename p) (buffer-file-name))) eclim--problems-list)
             do (eclim--problems-insert-highlight problem)))))
 
 (defadvice find-file (after eclim-problems-highlight-on-find-file activate)
@@ -186,7 +186,7 @@
         (widen)
         (let ((line (line-number-at-pos))
               (col (current-column)))
-          (or (find-if (lambda (p) (and (string= (assoc-default 'filename p) (file-truename buffer-file-name))
+          (or (cl-find-if (lambda (p) (and (string= (assoc-default 'filename p) (file-truename buffer-file-name))
                                         (= (assoc-default 'line p) line)))
                        eclim--problems-list)
               (error "No problem on this line")))))))
@@ -195,9 +195,9 @@
   (interactive)
   (let* ((p (eclim--problems-get-current-problem)))
     (funcall (if same-window
-         'find-file
-       'find-file-other-window)
-     (assoc-default 'filename p))
+                 'find-file
+               'find-file-other-window)
+             (assoc-default 'filename p))
     (eclim--problem-goto-pos p)))
 
 (defun eclim-problems-correct ()

--- a/eclimd.el
+++ b/eclimd.el
@@ -81,20 +81,20 @@ Return the string used for `match-string' if a match is found, and nil if the pr
 
 The caller must use `save-match-data' to preserve the match data if necessary."
   (let ((old-filter (process-filter proc))
-	(old-sentinel (process-sentinel proc))
-	(output "")
-	(terminated-p))
+        (old-sentinel (process-sentinel proc))
+        (output "")
+        (terminated-p))
     (set-process-filter proc (lambda (proc string)
-			       (setf output (concat output string))
-			       ;; Chain to the old filter
-			       (if old-filter
-				   (funcall old-filter proc string))))
+                               (setf output (concat output string))
+                               ;; Chain to the old filter
+                               (if old-filter
+                                   (funcall old-filter proc string))))
     (set-process-sentinel proc (lambda (proc state)
-				 (unless (eq 'run
-					     (process-status proc))
-				   (setf terminated-p t))))
+                                 (unless (eq 'run
+                                             (process-status proc))
+                                   (setf terminated-p t))))
     (while (and (not terminated-p)
-		(not (string-match regexp output)))
+                (not (string-match regexp output)))
       (accept-process-output proc))
     (set-process-sentinel proc old-sentinel)
     (set-process-filter proc old-filter)
@@ -107,9 +107,9 @@ It returns the port it is listening on"
   (let ((eclimd-start-regexp "Eclim Server Started on\\(?: port\\|:\\) \\(?:\\(?:[0-9]+\\.\\)\\{3\\}[0-9]+:\\)?\\([0-9]+\\)"))
     (save-match-data
       (let ((output (eclimd--match-process-output eclimd-start-regexp eclimd-process)))
-	(when output
-	  (setq eclimd-port (match-string 1 output))
-	  (message (concat "eclimd serving at port " eclimd-port)))))
+        (when output
+          (setq eclimd-port (match-string 1 output))
+          (message (concat "eclimd serving at port " eclimd-port)))))
     eclimd-port))
 
 (defun start-eclimd (workspace-dir)

--- a/emacs-eclim-pkg.el
+++ b/emacs-eclim-pkg.el
@@ -1,5 +1,8 @@
 (define-package "emacs-eclim" "0.3"
   "An interface to the Eclipse IDE."
-  '((json "1.2")
-    (popup "v0.5.2")
-    (s "1.9.0")))
+  '((auto-complete "1.5.0")
+    (company "0.8.12")
+    (json "1.2")
+    (popup "0.5.2")
+    (s "1.9.0")
+    (yasnippet "0.9.0.1")))

--- a/tests/emacs-eclim-linter-init.el
+++ b/tests/emacs-eclim-linter-init.el
@@ -1,0 +1,41 @@
+(add-to-list 'load-path "./tests")
+(add-to-list 'load-path "./tests/elisp-lint")
+
+(require 'package)
+(add-to-list 'package-archives
+             '("melpa" . "http://melpa.milkbox.net/packages/") t)
+(package-initialize)
+
+(require 'cl)
+
+(defun pkg-installed-p (pkg)
+  (package-installed-p (car pkg) (version-to-list (cadr pkg))))
+
+(condition-case err
+    (let* ((pkg-info
+            (with-temp-buffer
+              (insert-file-contents "emacs-eclim-pkg.el")
+              (goto-char (point-min))
+              (read (current-buffer))))
+           (name (cadr pkg-info))
+           (needed-packages (cadr (nth 4 pkg-info))))
+      (assert (equal name "emacs-eclim"))
+      (message "Loaded emacs-eclim-pkg.el")
+      (message "Installing dependencies: %S" needed-packages)
+      (if (every #'pkg-installed-p needed-packages)
+          (message "All dependencies present.")
+        (package-refresh-contents)
+        (dolist (p needed-packages)
+          (unless (pkg-installed-p p)
+            (package-install (car p))
+            (when (not (pkg-installed-p p))
+              (error (message "Failed to install %s at %s." p)))
+            ))))
+  (error (message "Error loading dependencies: %s" err)))
+
+(add-hook 'emacs-lisp-mode-hook
+          (lambda ()
+            ;; Use spaces, not tabs.
+            (setq indent-tabs-mode nil)))
+
+(require 'elisp-lint)


### PR DESCRIPTION
Work In Progress. It's not meant to be merged. At least not now. 

There was to many changes and I decided to share the burden. 

Problems:
* would be nice to fit everything in 80 chars
* macro calls uses for example `("-d" delimiters)` in arguments which misleads the linter
* lines that linter provides (or maybe compiler) are not inline with what is in sources
* bunch of compilation errors that I didn't resolve yet
* emacs asks about variables set in .dir-locals.el (so maybe better would be to move those to `emacs-eclim-linter-init.el`?)
* would be nice to have script that would run linting and tests (in future) also locally (ensime have something like this in [here](https://github.com/ensime/ensime-emacs/blob/master/test/run_emacs_tests.sh))

Goal is to have travis build green. And then we will keep it like that.