### PR TITLE
Use length of completion to find action start

### DIFF
--- a/company-emacs-eclim.el
+++ b/company-emacs-eclim.el
@@ -72,12 +72,13 @@
     (sorted t)
     (post-completion (let ((ann (company-emacs-eclim--annotation arg)))
                        (when ann
-                         (insert ann)
-                         (company-emacs-eclim-action ann))))))
+                         (insert ann))
+                         (company-emacs-eclim-action arg ann)))))
 
-(defun company-emacs-eclim-action (call)
+(defun company-emacs-eclim-action (completion annotation)
   (let* ((end (point))
-         (beg (- end (length call))))
+         (len (+ (length completion) (length annotation)))
+         (beg (- end len)))
     (eclim--completion-action beg end)))
 
 (provide 'company-emacs-eclim)

--- a/company-emacs-eclim.el
+++ b/company-emacs-eclim.el
@@ -73,7 +73,7 @@
     (post-completion (let ((ann (company-emacs-eclim--annotation arg)))
                        (when ann
                          (insert ann))
-                         (company-emacs-eclim-action arg ann)))))
+                       (company-emacs-eclim-action arg ann)))))
 
 (defun company-emacs-eclim-action (completion annotation)
   (let* ((end (point))


### PR DESCRIPTION
Call company-emacs-eclim-action even if there is no annotation on the
completion, and use the length of both the annotation and the completion
to determint the start and end passed to eclim--completion-action. This fixes #148 and #193, now the post completion action will always be called, and it will have correct values for the start and end of the completion.