### PR TITLE
Remove duplicate eclim modeline

### DIFF
--- a/eclim.el
+++ b/eclim.el
@@ -459,7 +459,7 @@ FILENAME is given, return that file's  project name instead."
 (define-minor-mode eclim-mode
   "An interface to the Eclipse IDE."
   nil
-  " Eclim"
+  (:eval (eclim-modeline-string))
   eclim-mode-map
   (if eclim-mode
       (progn
@@ -542,11 +542,8 @@ the use of eclim to java and ant files."
 (require 'eclim-maven)
 (require 'eclim-problems)
 
-(add-to-list 'minor-mode-alist
-             '(eclim-mode (:eval (eclim-modeline-string))))
-
 (defun eclim-modeline-string ()
   (when eclim-mode
-    (concat "Eclim " (eclim-problems-modeline-string))))
+    (concat " Eclim " (eclim-problems-modeline-string))))
 
 (provide 'eclim)


### PR DESCRIPTION
This removes the duplicate eclim entry in the modeline, now there is just the one created by define-minor-mode, and it uses `eclim-modeline-string` to update with eclim-problems information. 

Before this change you can see two entries for eclim in the modeline:
![bad-modeline](https://cloud.githubusercontent.com/assets/2257894/8589713/16c0547c-25ce-11e5-99d0-3457569bfc1b.png)


With this change, there is only a single eclim modeline entry:
![good-modeline](https://cloud.githubusercontent.com/assets/2257894/8589701/f3c75704-25cd-11e5-9010-3e02ae07cf41.png)

