### PR TITLE
Add jdb debug support for tests or ext process

### DIFF
--- a/eclim-ant.el
+++ b/eclim-ant.el
@@ -82,7 +82,7 @@ buildfile for the current project has changed and needs to be updated"
 (defun eclim-ant-validate (project file)
   "Run ant-xml validation against the file opened in the current
 buffer. The results are displayed in a dedicated compilation buffer."
-  (interactive (list (eclim--project-name) (buffer-file-name)))
+  (interactive (list (eclim-project-name) (buffer-file-name)))
   (pop-to-buffer (get-buffer-create "*eclim: build*"))
   (let ((buffer-read-only nil))
     (erase-buffer)
@@ -96,7 +96,7 @@ buffer. The results are displayed in a dedicated compilation buffer."
   "run a specified ant target in the scope of the current project. If
 the function is called interactively the users is presented with a
   list of all available ant targets."
-  (interactive (list (eclim--ant-read-target (eclim--project-name)
+  (interactive (list (eclim--ant-read-target (eclim-project-name)
                                              (eclim--ant-buildfile-name))))
   (let ((default-directory (eclim--ant-buildfile-path)))
     ;; TODO: use the right version of java to execute ant

--- a/eclim-debug.el
+++ b/eclim-debug.el
@@ -1,0 +1,148 @@
+;; eclim-debug.el --- an interface to the Eclipse IDE. -*- lexical-binding: t; -*-
+;;
+;; Copyright (C) 2015 Łukasz Klich
+;;
+;; Author: Lukasz Klich <klich.lukasz@gmail.com>
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+;;
+;;; Contributors
+;;
+;;; Conventions
+;;
+;; Conventions used in this file: Name internal variables and functions
+;; "eclim--<descriptive-name>", and name external program invocations
+;; "eclim/command-name", like eclim/project-list.
+;;; Description
+;;
+;; eclim-debug.el -- emacs-eclim integration with gud and jdb to
+;; support debugging
+;;
+
+(require 'eclim-project)
+(require 'eclim-java)
+(require 'eclim-maven)
+(require 'eclim-ant)
+(require 'gud)
+(require 'dash)
+(require 's)
+
+(define-key eclim-mode-map (kbd "C-c C-e p t") 'eclim-debug-test)
+(define-key eclim-mode-map (kbd "C-c C-e p a") 'eclim-debug-attach)
+
+(defun eclim--debug-jdb-attach-command (project port)
+  (let ((sourcepath (eclim--debug-sourcepath project)))
+    (format "jdb -attach %s -sourcepath%s "
+            port
+            sourcepath)))
+
+(defun eclim--debug-jdb-run-command (project args)
+  (let ((sourcepath (eclim--debug-sourcepath project))
+        (classpath (eclim/java-classpath project)))
+    (concat (format "jdb -sourcepath%s -classpath%s "
+                    sourcepath
+                    classpath)
+            (s-join " " args))))
+
+(defun eclim--debug-sourcepath (project)
+  (let ((projects (-snoc (eclim-project-dependencies project) project)))
+    (s-join ":" (-mapcat 'eclim--debug-project-sourcepath projects))))
+
+(defun eclim--debug-project-dir (project)
+  (cdr (assoc 'path (eclim/project-info project))))
+
+(defun eclim--debug-project-sourcepath (project)
+  (eclim--debug-read-sourcepath
+   (concat (file-name-as-directory (eclim--debug-project-dir project))
+           ".classpath")))
+
+(defun eclim--debug-read-sourcepath (classpath-file)
+  (let* ((root (car (xml-parse-file classpath-file)))
+         (classpathentries (xml-get-children root 'classpathentry))
+         (srcs (-filter 'eclim--debug-kind-src? classpathentries))
+         (paths-relative (-map 'eclim--debug-get-path srcs))
+         (paths-absolute (--map (concat (file-name-directory classpath-file) it) paths-relative)))
+    paths-absolute))
+
+(defun eclim--debug-kind-src? (classpathentry)
+  (let* ((attrs (xml-node-attributes classpathentry))
+         (kind (cdr (assq 'kind attrs))))
+    (string-equal kind "src")))
+
+(defun eclim--debug-get-path (classpathentry)
+  (let* ((attrs (xml-node-attributes classpathentry))
+         (path (cdr (assq 'path attrs))))
+    path))
+
+(defun eclim--debug-attach-when-ready (txt project port)
+  (when (s-contains? (concat "at address: " (number-to-string port)) txt)
+    (remove-hook 'comint-output-filter-functions
+                 'eclim--debug-attach-when-ready
+                 t)
+    (eclim-debug-attach port project)))
+
+(defun eclim--debug-maven-run ()
+  (concat "mvn -f " (eclim--maven-pom-path)
+          "clean test -Dmaven.surefire.debug -Dtest=" (file-name-base)))
+
+(defun eclim--debug-project-maven? ()
+  (eclim--debug-file-exists-in-project-root? "pom.xml"))
+
+(defun eclim--debug-ant-run (target)
+  (let ((default-directory (eclim--ant-buildfile-path)))
+    "ANT_OPTS=\"$ANT_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005\" ant test"))
+
+(defun eclim--debug-project-ant? ()
+  (eclim--debug-file-exists-in-project-root? "build.xml"))
+
+(defun eclim--debug-file-exists-in-project-root? (filename)
+  (let* ((project-dir (eclim--debug-project-dir eclim-project-name))
+         (file (concat project-dir filename)))
+    (file-exists-p file)))
+
+(defun eclim--debug-run-process-and-attach (command port)
+  (let ((project eclim-project-name))
+    (with-current-buffer (compile command t)
+      (setq-local comint-prompt-read-only t)
+      (make-local-variable 'comint-output-filter-functions)
+      (add-hook 'comint-output-filter-functions
+                (lambda (txt) (eclim--debug-attach-when-ready txt project port))))))
+
+(defun eclim-debug-junit ()
+  (interactive)
+  (let ((project eclim-project-name)
+        (classes (list "org.junit.runner.JUnitCore"
+                       (eclim-package-and-class))))
+    (jdb (eclim--debug-jdb-run-command project classes))))
+
+(defun eclim-debug-maven-test ()
+  (interactive)
+  (eclim--debug-run-process-and-attach (eclim--debug-maven-run) 5005))
+
+(defun eclim-debug-ant-test ()
+  (interactive)
+  (eclim--debug-run-process-and-attach (eclim--debug-ant-run) 5005))
+
+(defun eclim-debug-attach (port project)
+  (interactive (list (read-number "Port: " 5005) eclim-project-name))
+  (jdb (eclim--debug-jdb-attach-command project port)))
+
+(defun eclim-debug-test ()
+  (interactive)
+  (cond ((eclim-java-junit-buffer?) (eclim-debug-junit))
+        ((eclim--debug-project-maven?) (eclim-debug-maven-test))
+        ((eclim--debug-projecta-ant?) (eclim-debug-ant-test))
+        (t (message "I can't debug this. I wasn't program smart enough. Please help me"))))
+
+(provide 'eclim-debug)

--- a/eclim-java.el
+++ b/eclim-java.el
@@ -129,7 +129,7 @@ in eclim when appropriate."
   (let ((pr nil)
         (fn nil))
     (ignore-errors
-      (and (setq pr (eclim--project-name filename))
+      (and (setq pr (eclim-project-name filename))
            (setq fn (file-relative-name filename (eclim--project-dir pr)))))
     ad-do-it
     (when (and pr fn)
@@ -211,7 +211,7 @@ has been found."
 
 (defun eclim-java-generate-getter-and-setter (project file offset encoding)
   "Generates getter and setter methods for the symbol at point."
-  (interactive (list (eclim--project-name)
+  (interactive (list (eclim-project-name)
                      (eclim--project-current-file)
                      (eclim--byte-offset)
                      (eclim--current-encoding)))
@@ -266,7 +266,7 @@ has been found."
       (message "Done"))))
 
 (defun eclim-java-call-hierarchy (project file encoding)
-  (interactive (list (eclim--project-name)
+  (interactive (list (eclim-project-name)
                      (eclim--project-current-file)
                      (eclim--current-encoding)))
   (let ((boundary "\\([<>()\\[\\.\s\t\n!=,;]\\|]\\)"))
@@ -299,7 +299,7 @@ has been found."
           do (eclim--java-insert-call-hierarchy-node project caller (1+ level)))))
 
 (defun eclim-java-hierarchy (project file offset encoding)
-  (interactive (list (eclim--project-name)
+  (interactive (list (eclim-project-name)
                      (eclim--project-current-file)
                      (eclim--byte-offset)
                      (eclim--current-encoding)))
@@ -542,7 +542,7 @@ method."
   (interactive)
   (if (not (string= major-mode "java-mode"))
       (message "Sorry cannot run current buffer.")
-    (compile (concat eclim-executable " -command java -p "  eclim--project-name
+    (compile (concat eclim-executable " -command java -p "  eclim-project-name
                      " -c " (eclim-package-and-class)))))
 
 (defun eclim--java-junit-file (project file offset encoding)
@@ -569,19 +569,25 @@ method."
    :value (cdr (assoc 'index correction))
    :document (cdr (assoc 'preview correction))))
 
+(defun eclim-java-junit-buffer? ()
+  (eclim--buffer-contains-substring "org.junit.Test"))
+
+(defun eclim-java-testng-buffer? ()
+  (eclim--buffer-contains-substring "org.testng.annotations.Test"))
+
 (defun eclim-run-junit (project file offset encoding)
   "Run the current JUnit tests for current project or
 current class or current method.
 
 This method hooks onto the running Eclipse process and is thus
 much faster than running mvn test -Dtest=TestClass#method."
-  (interactive (list (eclim--project-name)
+  (interactive (list (eclim-project-name)
                      (eclim--project-current-file)
                      (eclim--byte-offset)
                      (eclim--current-encoding)))
   (if (not (string= major-mode "java-mode"))
       (message "Running JUnit tests only makes sense for Java buffers.")
-    (compile (if (eclim--buffer-contains-substring "@Test")
+    (compile (if (eclim-java-junit-buffer?)
                  (eclim--java-junit-file project file offset encoding)
                (eclim--java-junit-project project encoding)))))
 
@@ -594,7 +600,7 @@ much faster than running mvn test -Dtest=TestClass#method."
                  (choice (popup-menu* cmenu)))
           (eclim/with-results correction-info
             ("java_correct"
-             ("-p" eclim--project-name)
+             ("-p" eclim-project-name)
              "-f"
              ("-l" line)
              ("-o" offset)
@@ -609,7 +615,7 @@ much faster than running mvn test -Dtest=TestClass#method."
         (let ((bounds (bounds-of-thing-at-point 'symbol))
               (window-config (current-window-configuration)))
           (eclim/with-results doc ("java_element_doc"
-                                   ("-p" (eclim--project-name))
+                                   ("-p" (eclim-project-name))
                                    "-f"
                                    ("-l" (- (cdr bounds) (car bounds)))
                                    ("-o" (save-excursion

--- a/eclim-maven.el
+++ b/eclim-maven.el
@@ -49,6 +49,8 @@
   (let ((default-directory (eclim--project-dir)))
     (compile (concat "mvn -f " (eclim--maven-pom-path) " " command))))
 
+
+
 (defun eclim-maven-run (goal)
   "Execute a specific Maven goal in the context of the current
 project. The build output is displayed in the *compilation* buffer."

--- a/eclim-problems.el
+++ b/eclim-problems.el
@@ -345,7 +345,7 @@ create and initialize a new buffer."
   (or (get-buffer "*eclim: problems*")
       (let ((buf (get-buffer-create "*eclim: problems*")))
         (save-excursion
-          ;; (setq eclim--problems-project (eclim--project-name))
+          ;; (setq eclim--problems-project (eclim-project-name))
           (setq eclim--problems-file buffer-file-name)
           (set-buffer buf)
           (eclim--problems-mode)
@@ -358,7 +358,7 @@ argument QUIET is non-nil, open the buffer in the background
 without switching to it."
   (let ((buf (get-buffer-create "*eclim: problems*")))
     (save-excursion
-      (setq eclim--problems-project (eclim--project-name))
+      (setq eclim--problems-project (eclim-project-name))
       (setq eclim--problems-file buffer-file-name)
       (set-buffer buf)
       (eclim--problems-mode)
@@ -370,7 +370,7 @@ without switching to it."
 (defun eclim-problems ()
   "Show current compilation problems in a separate window."
   (interactive)
-  (if (eclim--project-name)
+  (if (eclim-project-name)
       (eclim--problems-mode-init)
     (error "Could not figure out the current project. Is this an eclim managed buffer?")))
 
@@ -390,7 +390,7 @@ without switching to it."
 (defun eclim-problems-refocus ()
   (interactive)
   (when (eclim--project-dir)
-    (setq eclim--problems-project (eclim--project-name))
+    (setq eclim--problems-project (eclim-project-name))
     (setq eclim--problems-file buffer-file-name)
     (with-current-buffer eclim--problems-buffer-name
       (eclim-problems-buffer-refresh))))
@@ -429,7 +429,7 @@ refresh of the problems buffer."
   (when (and (not eclim--is-completing)
              (eclim--project-dir)
              eclim-autoupdate-problems)
-    (setq eclim--problems-project (eclim--project-name))
+    (setq eclim--problems-project (eclim-project-name))
     (setq eclim--problems-file buffer-file-name)
     (run-with-idle-timer eclim-problems-refresh-delay nil (lambda () (eclim-problems-buffer-refresh)))))
 

--- a/eclim-project.el
+++ b/eclim-project.el
@@ -91,7 +91,7 @@
 
 (defun eclim--project-set-current ()
   (ignore-errors
-    (setq eclim--project-name (eclim--project-current-line))))
+    (setq eclim-project-name (eclim--project-current-line))))
 
 (defun eclim--project-buffer-refresh ()
   (eclim--project-clear-cache)
@@ -262,19 +262,22 @@
 
 (defun eclim-project-nature-add (nature)
   (interactive (list (eclim--project-nature-read)))
-  (message (eclim/project-nature-add eclim--project-name nature)))
+  (message (eclim/project-nature-add eclim-project-name nature)))
 
 (defun eclim-project-nature-remove (nature)
   (interactive (list (completing-read "Remove nature: "
                                       (append
-                                       (cdadr (aref (eclim/project-natures eclim--project-name) 0))
+                                       (cdadr (aref (eclim/project-natures eclim-project-name) 0))
                                        nil))))
-  (message (eclim/project-nature-remove eclim--project-name nature)))
+  (message (eclim/project-nature-remove eclim-project-name nature)))
 
 (defun eclim-project-natures ()
   (interactive)
   (message (with-output-to-string
-             (princ (cdadr (aref (eclim/project-natures eclim--project-name) 0))))))
+             (princ (cdadr (aref (eclim/project-natures eclim-project-name) 0))))))
+
+(defun eclim-project-dependencies (project)
+  (cdr (assoc 'depends (eclim/project-info project))))
 
 (defun eclim-project-mode-refresh ()
   (interactive)

--- a/eclim.el
+++ b/eclim.el
@@ -105,8 +105,8 @@ in the current workspace."
   :type '(choice (const :tag "Off" nil)
                  (const :tag "On" t)))
 
-(defvar eclim--project-name nil)
-(make-variable-buffer-local 'eclim--project-name)
+(defvar eclim-project-name nil)
+(make-variable-buffer-local 'eclim-project-name)
 
 (defvar eclim--project-current-file nil)
 (make-variable-buffer-local 'eclim--project-current-file)
@@ -212,8 +212,8 @@ strings and will be called on completion."
             (set-process-sentinel proc sentinel)))))))
 
 (setq eclim--default-args
-      '(("-n" . (eclim--project-name))
-        ("-p" . (or (eclim--project-name) (error "Could not find eclipse project for %s" (buffer-name (current-buffer)))))
+      '(("-n" . (eclim-project-name))
+        ("-p" . (or (eclim-project-name) (error "Could not find eclipse project for %s" (buffer-name (current-buffer)))))
         ("-e" . (eclim--current-encoding))
         ("-f" . (eclim--project-current-file))
         ("-o" . (eclim--byte-offset))
@@ -252,7 +252,7 @@ lists are then appended together."
     (when sync (eclim/java-src-update))
     (when check
       (ignore-errors
-        (eclim--check-project (if (listp check) (eval (second check)) (eclim--project-name)))))
+        (eclim--check-project (if (listp check) (eval (second check)) (eclim-project-name)))))
     (let ((attrs-before (if sync (file-attributes (buffer-file-name)) nil)))
       (funcall executor (cons cmd expargs)
                (lambda ()
@@ -333,22 +333,22 @@ value is computed for that file's instead."
   (ignore-errors
     (let ((file (or filename buffer-file-name)))
       (and file
-           (eclim--project-name file)))))
+           (eclim-project-name file)))))
 
 (defun eclim--project-dir (&optional projectname)
   "Return this project's root directory. If the optional
 argument PROJECTNAME is given, return that project's root directory."
-  (assoc-default 'path (eclim/project-info (or projectname (eclim--project-name)))))
+  (assoc-default 'path (eclim/project-info (or projectname (eclim-project-name)))))
 
-(defun eclim--project-name (&optional filename)
+(defun eclim-project-name (&optional filename)
   "Returns this file's project name. If the optional argument
 FILENAME is given, return that file's  project name instead."
   (labels ((get-project-name (file)
                              (eclim/execute-command "project_by_resource" ("-f" file))))
     (if filename
         (get-project-name filename)
-      (or eclim--project-name
-          (and buffer-file-name (setq eclim--project-name (get-project-name buffer-file-name)))))))
+      (or eclim-project-name
+          (and buffer-file-name (setq eclim-project-name (get-project-name buffer-file-name)))))))
 
 (defun eclim--find-file (path-to-file)
   (if (not (string-match-p "!" path-to-file))
@@ -464,7 +464,7 @@ FILENAME is given, return that file's  project name instead."
   (if eclim-mode
       (progn
         (kill-local-variable 'eclim--project-dir)
-        (kill-local-variable 'eclim--project-name)
+        (kill-local-variable 'eclim-project-name)
         (kill-local-variable 'eclim--project-current-file)
         (add-hook 'after-save-hook 'eclim--problems-update-maybe nil 't)
         (add-hook 'after-save-hook 'eclim--after-save-hook nil 't))


### PR DESCRIPTION
New features:
* debug junit class
* debug mvn tests ran for single class
* attach to process

All debug options includes sourcepath so sources are correctly showed

Unfortunatelly I don't have any tests. I'm waiting on `ecukes` :wink: I know how to run test in debug programmatically and how to end it, so I hope tests won't be impossibly hard.