### PR TITLE
Use Occur to show Java Definitions in a buffer

### DIFF
--- a/eclim-java.el
+++ b/eclim-java.el
@@ -43,6 +43,7 @@
 (define-key eclim-mode-map (kbd "C-c C-e f s") 'eclim-java-format)
 (define-key eclim-mode-map (kbd "C-c C-e g") 'eclim-java-generate-getter-and-setter)
 (define-key eclim-mode-map (kbd "C-c C-e t") 'eclim-run-junit)
+(define-key eclim-mode-map (kbd "C-c C-e j") 'eclim-java-occur-definitions)
 
 (defvar eclim-java-show-documentation-map
   (let ((map (make-keymap)))
@@ -568,6 +569,17 @@ method."
    (cdr (assoc 'description correction))
    :value (cdr (assoc 'index correction))
    :document (cdr (assoc 'preview correction))))
+
+(defun eclim-java-occur-definitions ()
+  "Show class and method definitions in a new buffer"
+  (interactive)
+  (let ((list-matching-lines-face nil))
+    (occur "^ *\\(private\\|public\\|protected\\) .*\\(,\\|{\\)"
+           ))
+  (let ((window (get-buffer-window "*Occur*")))
+    (if window
+        (select-window window)
+      (switch-to-buffer "*Occur*"))))
 
 (defun eclim-run-junit (project file offset encoding)
   "Run the current JUnit tests for current project or


### PR DESCRIPTION
Can now show java classes and methods in a diff buffer just like below. Wasn't sure what keybinding to use so I stuck with `C-c C-e j`

![occur](https://cloud.githubusercontent.com/assets/1545083/8768795/f9b4786a-2e40-11e5-9353-c9f6892f7c32.png)
