### PR TITLE
Set line-move-visual buffer local in eclim-project

### DIFF
--- a/eclim-project.el
+++ b/eclim-project.el
@@ -375,9 +375,9 @@
         mode-name "eclim/project"
         mode-line-process ""
         truncate-lines t
-        line-move-visual nil
         buffer-read-only t
         default-directory (eclim/workspace-dir))
+  (setq-local line-move-visual nil)
   (put 'eclim-project-mode 'mode-class 'special)
   (hl-line-mode t)
   (use-local-map eclim-project-mode-map)


### PR DESCRIPTION
Set line-move-visual as a buffer local variable in eclim-project-mode to
avoid overriding any user preferences. All other variables set by
eclim-project-mode automatically become buffer local when set.