### PR TITLE
Add a command to refresh an eclipse project

### DIFF
--- a/eclim-project.el
+++ b/eclim-project.el
@@ -49,6 +49,7 @@
     (define-key map (kbd "g") 'eclim-project-mode-refresh)
     (define-key map (kbd "R") 'eclim-project-rename)
     (define-key map (kbd "q") 'eclim-quit-window)
+    (define-key map (kbd "r") 'eclim-project-refresh)
     map))
 
 (defvar eclim-project-info-mode-map
@@ -300,6 +301,13 @@
   (when (not (listp projects)) (set 'projects (list projects)))
   (dolist (project projects)
     (eclim/project-close project))
+  (eclim--project-buffer-refresh))
+
+(defun eclim-project-refresh (projects)
+  (interactive (list (eclim--project-read)))
+  (when (not (listp projects)) (set 'projects (list projects)))
+  (dolist (project projects)
+    (eclim/project-refresh project))
   (eclim--project-buffer-refresh))
 
 (defun eclim-project-mark-current ()


### PR DESCRIPTION
This command will call project_refresh on the desired projects. Bind the
command to 'r' in eclim-project-mode-map.

This is a function that is useful if the project's files have been modified outside of emacs or eclipse, such as by a version control system.
