### PR TITLE
Fix class hierarchy file links

### DIFF
--- a/eclim-java.el
+++ b/eclim-java.el
@@ -303,8 +303,7 @@ has been found."
                      (eclim--project-current-file)
                      (eclim--byte-offset)
                      (eclim--current-encoding)))
-  (let ((top-node (eclim--java-insert-file-path-for-hierarchy-nodes
-                   (eclim/java-hierarchy project file offset encoding))))
+  (let ((top-node (eclim/java-hierarchy project file offset encoding)))
     (pop-to-buffer "*eclim: hierarchy*" t)
     (special-mode)
     (let ((buffer-read-only nil))
@@ -314,22 +313,15 @@ has been found."
        top-node
        0))))
 
-(defun eclim--java-insert-file-path-for-hierarchy-nodes (node)
-                                        ;Can't use *-find-type here because it will pop a buffer
-                                        ;that isn't part of the project which then breaks future
-                                        ;*-find-type calls and isn't what we want here anyway.
+(defun eclim--java-insert-file-path-for-hierarchy-node (node)
   (eclim/with-results hits ("java_search" ("-p" (cdr (assoc 'qualified node))) ("-t" "type") ("-x" "declarations") ("-s" "workspace"))
-    (add-to-list 'node `(file-path . ,(assoc-default 'message (elt hits 0))))
-    (let ((children (cdr (assoc 'children node))))
-      (loop for child across children do
-            (eclim--java-insert-file-path-for-hierarchy-nodes child)))
-    node))
+    (assoc-default 'filename (elt hits 0))))
 
 (defun eclim--java-insert-hierarchy-node (project node level)
   (let ((declaration (cdr (assoc 'name node)))
         (qualified-name (cdr (assoc 'qualified node))))
     (insert (format (concat "%-"(number-to-string (* level 2)) "s=> ") ""))
-    (lexical-let ((file-path (cdr (assoc 'file-path node))))
+    (lexical-let ((file-path (eclim--java-insert-file-path-for-hierarchy-node node)))
       (if file-path
           (insert-text-button declaration
                               'follow-link t


### PR DESCRIPTION
The tree was traversed twice. First information about file-path was
added and then it was once again traversed to actually print it.
Unfortunately adding information about file-path was changing only first
node without touching children.

New implementation drops the first tree traverse and retrieves
information about file-path when each node is inserted.

Minor thing. Wrong field was assoc from response. It should be 
`filename` instead of `message`