### PR TITLE
Use function eclim-project-name everywhere

### DIFF
--- a/eclim-debug.el
+++ b/eclim-debug.el
@@ -79,12 +79,12 @@
   (eclim--debug-file-exists-in-project-root? "build.xml"))
 
 (defun eclim--debug-file-exists-in-project-root? (filename)
-  (let* ((project-dir (eclim-java-run--project-dir eclim-project-name))
+  (let* ((project-dir (eclim-java-run--project-dir (eclim-project-name)))
          (file (concat project-dir filename)))
     (file-exists-p file)))
 
 (defun eclim--debug-run-process-and-attach (command port)
-  (let ((project eclim-project-name))
+  (let ((project (eclim-project-name)))
     (with-current-buffer (compile command t)
       (setq-local comint-prompt-read-only t)
       (make-local-variable 'comint-output-filter-functions)
@@ -93,7 +93,7 @@
 
 (defun eclim-debug-junit ()
   (interactive)
-  (let ((project eclim-project-name)
+  (let ((project (eclim-project-name))
         (classes (eclim-package-and-class)))
     (jdb (eclim--debug-jdb-run-command project "org.junit.runner.JUnitCore" classes))))
 
@@ -106,7 +106,7 @@
   (eclim--debug-run-process-and-attach (eclim--debug-ant-run) 5005))
 
 (defun eclim-debug-attach (port project)
-  (interactive (list (read-number "Port: " 5005) eclim-project-name))
+  (interactive (list (read-number "Port: " 5005) (eclim-project-name)))
   (jdb (eclim--debug-jdb-attach-command project port)))
 
 (defun eclim-debug-test ()

--- a/eclim-java-run.el
+++ b/eclim-java-run.el
@@ -127,20 +127,20 @@
 (defun eclim-java-run--ask-which-configuration ()
   (completing-read "Which configuration do you want to run?"
                    (--map (cdr (assoc 'name it))
-                          (eclim-java-run--load-configurations eclim-project-name))
+                          (eclim-java-run--load-configurations (eclim-project-name)))
                    nil t))
 
 (defun eclim-java-run-run (configuration-name)
   (interactive (list (eclim-java-run--ask-which-configuration)))
-  (let* ((configurations (eclim-java-run--load-configurations eclim-project-name))
+  (let* ((configurations (eclim-java-run--load-configurations (eclim-project-name)))
          (configuration (eclim-java-run--configuration configuration-name configurations))
-         (project-dir (eclim-java-run--project-dir eclim-project-name))
-         (classpath (eclim/java-classpath eclim-project-name))
+         (project-dir (eclim-java-run--project-dir (eclim-project-name)))
+         (classpath (eclim/java-classpath (eclim-project-name)))
          (debug? (eclim-java-run--jdb? configuration)))
     (if debug?
         (eclim-java-run--run-jdb configuration
                                  classpath
-                                 (eclim-java-run-sourcepath eclim-project-name)
+                                 (eclim-java-run-sourcepath (eclim-project-name))
                                  project-dir)
       (eclim-java-run--run-java configuration
                                 classpath

--- a/eclim-java.el
+++ b/eclim-java.el
@@ -533,7 +533,7 @@ method."
   (interactive)
   (if (not (string= major-mode "java-mode"))
       (message "Sorry cannot run current buffer.")
-    (compile (concat eclim-executable " -command java -p "  eclim-project-name
+    (compile (concat eclim-executable " -command java -p "  (eclim-project-name)
                      " -c " (eclim-package-and-class)))))
 
 (defun eclim--java-junit-file (project file offset encoding)
@@ -591,7 +591,7 @@ much faster than running mvn test -Dtest=TestClass#method."
                  (choice (popup-menu* cmenu)))
           (eclim/with-results correction-info
             ("java_correct"
-             ("-p" eclim-project-name)
+             ("-p" (eclim-project-name))
              "-f"
              ("-l" line)
              ("-o" offset)

--- a/eclim-project.el
+++ b/eclim-project.el
@@ -90,10 +90,6 @@
     (eclim--completing-read "Project: "
                             (mapcar (lambda (p) (assoc-default 'name p)) (eclim/project-list)))))
 
-(defun eclim--project-set-current ()
-  (ignore-errors
-    (setq eclim-project-name (eclim--project-current-line))))
-
 (defun eclim--project-buffer-refresh ()
   (eclim--project-clear-cache)
   (when (eq major-mode 'eclim-project-mode)
@@ -263,19 +259,19 @@
 
 (defun eclim-project-nature-add (nature)
   (interactive (list (eclim--project-nature-read)))
-  (message (eclim/project-nature-add eclim-project-name nature)))
+  (message (eclim/project-nature-add (eclim--project-current-line) nature)))
 
 (defun eclim-project-nature-remove (nature)
   (interactive (list (completing-read "Remove nature: "
                                       (append
-                                       (cdadr (aref (eclim/project-natures eclim-project-name) 0))
+                                       (cdadr (aref (eclim/project-natures (eclim--project-current-line)) 0))
                                        nil))))
-  (message (eclim/project-nature-remove eclim-project-name nature)))
+  (message (eclim/project-nature-remove (eclim--project-current-line) nature)))
 
 (defun eclim-project-natures ()
   (interactive)
   (message (with-output-to-string
-             (princ (cdadr (aref (eclim/project-natures eclim-project-name) 0))))))
+             (princ (cdadr (aref (eclim/project-natures (eclim--project-current-line)) 0))))))
 
 (defun eclim-project-dependencies (project)
   (cdr (assoc 'depends (eclim/project-info project))))
@@ -394,7 +390,6 @@
   (use-local-map eclim-project-mode-map)
   (cd "~") ;; setting a defualt directoy avoids some problems with tramp
   (eclim--project-buffer-refresh)
-  (add-hook 'post-command-hook 'eclim--project-set-current nil t)
   (beginning-of-buffer)
   (run-mode-hooks 'eclim-project-mode-hook))
 

--- a/eclim.el
+++ b/eclim.el
@@ -105,11 +105,9 @@ in the current workspace."
   :type '(choice (const :tag "Off" nil)
                  (const :tag "On" t)))
 
-(defvar eclim-project-name nil)
-(make-variable-buffer-local 'eclim-project-name)
+(defvar-local eclim--project-name nil)
 
-(defvar eclim--project-current-file nil)
-(make-variable-buffer-local 'eclim--project-current-file)
+(defvar-local eclim--project-current-file nil)
 
 (defvar eclim--project-natures-cache nil)
 (defvar eclim--projects-cache nil)
@@ -347,8 +345,8 @@ FILENAME is given, return that file's  project name instead."
                              (eclim/execute-command "project_by_resource" ("-f" file))))
     (if filename
         (get-project-name filename)
-      (or eclim-project-name
-          (and buffer-file-name (setq eclim-project-name (get-project-name buffer-file-name)))))))
+      (or eclim--project-name
+          (and buffer-file-name (setq eclim--project-name (get-project-name buffer-file-name)))))))
 
 (defun eclim--find-file (path-to-file)
   (if (not (string-match-p "!" path-to-file))


### PR DESCRIPTION
Variable with the same name wasn't set in many situations. Use of
function will fix this cause. Also I removed a little bit misleading
usage and setting value to eclim-project-name (the var) in
eclim-project. Reading straight from current line should be used instead
when project name is needed.