### PR TITLE
Added eclim encoding mapping for iso-latin-1-unix

### DIFF
--- a/eclim.el
+++ b/eclim.el
@@ -115,6 +115,7 @@ in the current workspace."
 (defvar eclim--file-coding-system-mapping
   '(("undecided-dos" . "iso-8859-1")
     ("dos" . "iso-8859-1")
+    ("iso-latin-1-unix" . "iso-8859-1")
     ("undecided-unix" . "iso-8859-1")
     ("utf-8-dos" . "utf-8")
     ("utf-8-unix" . "utf-8")


### PR DESCRIPTION
- local buffers using iso-latin-1-unix can now interact with eclim
  (otherwise, various emacs-eclim shortcuts would not work).
- for future reference, to find the correct to-value for this map, see
  this overview of support encodings in Java:
  https://docs.oracle.com/javase/8/docs/technotes/guides/intl/encoding.doc.html
