### PR TITLE
Ignore errors when deciding whether to handle a file in global-eclim-…

### DIFF
--- a/eclim.el
+++ b/eclim.el
@@ -529,10 +529,12 @@ the use of eclim to java and ant files."
 ;;;###autoload
 (define-globalized-minor-mode global-eclim-mode eclim-mode
   (lambda ()
-    (if (and buffer-file-name
-             (eclim--accepted-p buffer-file-name)
-             (eclim--project-dir))
-        (eclim-mode 1))))
+    ;; Errors here can REALLY MESS UP AN EMACS SESSION. Can't emphasize enough.
+    (ignore-errors
+      (if (and buffer-file-name
+               (eclim--accepted-p buffer-file-name)
+               (eclim--project-dir))
+          (eclim-mode 1)))))
 
 (require 'eclim-project)
 (require 'eclim-java)


### PR DESCRIPTION
…mode.

(While you're looking at my other stuff, ran into this problem recently)

Otherwise a bad Eclipse state can cause an Emacs session to get very
unpleasant. I'm not sure exactly what the mechanism is, but basic stuff
like find-file, switch-buffer and *the M-x prompt* (of all things) stop
working with the Eclipse error.

To reproduce, define eclim--project-dir to (error something), then open a
managed Java file not already open. Have the real eclim--project-dir ready;
fortunately, eval-expression still works.

The user can run eclim-mode manually if they want to investigate the error,
or try to do anything that needs project-dir.  I think even printing a
message would still be too unpleasant in that state, hence ignore.