### PR TITLE
Adds command for starting elimd with a given rc file

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -4,6 +4,7 @@
 
 === New features
  * company mode completion can be case insensitive
+ * start eclimd with a given .eclimrc file
 
 == 0.3
 

--- a/eclimd.el
+++ b/eclimd.el
@@ -131,6 +131,22 @@ It returns the port it is listening on"
         (when eclimd-wait-for-process
           (wait-eclimd-start))))))
 
+(defun start-eclimd-rc (eclimd-rc-file)
+  (interactive (list (read-file-name "Eclimdrc file: " "~/" nil t)))
+  (let ((eclimd-prog (eclimd--executable-path)))
+    (if (not eclimd-prog)
+        (message "Cannot start eclimd: check eclimd-executable variable.")
+      (if (eclimd--running-p)
+          (message "Cannot start eclimd: eclimd is already running.")
+        (message (concat "Starting eclimd with rc file: " eclimd-rc-file "..."))
+        (setq eclimd-process-buffer
+              (make-comint eclimd-process-buffer-name
+                           eclimd-prog
+                           eclimd-rc-file))
+        (setq eclimd-process (get-buffer-process eclimd-process-buffer))
+        (when eclimd-wait-for-process
+          (wait-eclimd-start))))))
+
 (defun stop-eclimd ()
   (interactive)
   (when eclimd-process


### PR DESCRIPTION
This PR adds a new command to start the eclim daemaon with emacs with a given runtime configuration file. It is useful for people working with multiple workspaces and/or using different jvm arg configurations for e.g. memory.

Hope you find this useful too!
