### PR TITLE
added eclim-java-generate-getter

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -4,6 +4,8 @@
 
 === New features
  * company mode completion can be case insensitive
+ * added eclim-run-configuartion which runs a run configuration in the
+   compilation buffer.
 
 == 0.3
 

--- a/History.txt
+++ b/History.txt
@@ -6,6 +6,8 @@
  * company mode completion can be case insensitive
  * added eclim-run-configuartion which runs a run configuration in the
    compilation buffer.
+ * added eclim-java-generate-getter which generates a getter method
+ for the symbol at point.
 
 == 0.3
 

--- a/eclim-java-run.el
+++ b/eclim-java-run.el
@@ -146,5 +146,19 @@
                                 classpath
                                 project-dir))))
 
+(defun eclim-run-configuartion (configuration-name)
+      "Runs the configuration given in CONFIGURATION-NAME in the compilation buffer."
+      (interactive (list (eclim-java-run--ask-which-configuration)))
+      (let* ((current-directory default-directory)
+             (configurations (eclim-java-run--load-configurations (eclim-project-name)))
+             (configuration (eclim-java-run--configuration configuration-name configurations))
+             (project-dir (eclim-java-run--project-dir (eclim-project-name)))
+             (classpath (eclim/java-classpath (eclim-project-name)))
+             (command (eclim-java-run--command configuration (eclim-java-run--java-vm-args classpath))))
+        (setq default-directory project-dir)
+        (compile command)
+        (setq default-directory current-directory)
+        ))
+
 (provide 'eclim-java-run)
 ;;; eclim-java-run.el ends here

--- a/eclim-java.el
+++ b/eclim-java.el
@@ -174,6 +174,17 @@ declaration has been found. TYPE may be either 'class',
 has been found."
   (eclim--java-current-type-name "\\(class\\)"))
 
+(defun eclim--java-generate-bean-properties (project file offset encoding type)
+  "Generates a bean property for the symbol at point. TYPE specifies the property to generate."
+  (eclim--call-process "java_bean_properties"
+                       "-p" project
+                       "-f" file
+                       "-o" (number-to-string offset)
+                       "-e" encoding
+                       "-r" (cdr (eclim--java-identifier-at-point t))
+                       "-t" type)
+  (revert-buffer t t t))
+
 (defun eclim/java-classpath (project)
   (eclim--check-project project)
   (eclim--call-process "java_classpath" "-p" project))
@@ -215,15 +226,15 @@ has been found."
                      (eclim--project-current-file)
                      (eclim--byte-offset)
                      (eclim--current-encoding)))
+  (eclim--java-generate-bean-properties project file offset encoding "gettersetter"))
 
-  (eclim--call-process "java_bean_properties"
-                       "-p" project
-                       "-f" file
-                       "-o" (number-to-string offset)
-                       "-e" encoding
-                       "-r" (cdr (eclim--java-identifier-at-point t))
-                       "-t" "gettersetter")
-  (revert-buffer t t t))
+(defun eclim-java-generate-getter (project file offset encoding)
+  "Generates a getter method for the symbol at point."
+  (interactive (list (eclim-project-name)
+                     (eclim--project-current-file)
+                     (eclim--byte-offset)
+                     (eclim--current-encoding)))
+  (eclim--java-generate-bean-properties project file offset encoding "getter"))
 
 (defun eclim-java-constructor ()
   (interactive)


### PR DESCRIPTION
`eclim-java-generate-getter` generates a getter method for the symbol at point and does modify the declaration if the member is `final`.

Calling `eclim-java-generate-getter-and-setter` on a member that is `final` removes the `final` keyword from the declaration.