### PR TITLE
add quotes around project and file names when running as junit test

### DIFF
--- a/eclim-java.el
+++ b/eclim-java.el
@@ -538,8 +538,8 @@ method."
 
 (defun eclim--java-junit-file (project file offset encoding)
      (concat eclim-executable
-             " -command java_junit -p " project
-             " -f " file
+             " -command java_junit -p \"" project "\""
+             " -f \"" file "\""
              " -o " (number-to-string offset)
              " -e " encoding))
 


### PR DESCRIPTION
Just encountered a problem when I could not run JUnit tests because my project name had a single quote in it. This commit should fix this.